### PR TITLE
[YS-67] feat: 실험자 회원가입 API 구현

### DIFF
--- a/src/main/kotlin/com/dobby/backend/application/mapper/OauthUserMapper.kt
+++ b/src/main/kotlin/com/dobby/backend/application/mapper/OauthUserMapper.kt
@@ -3,7 +3,7 @@ package com.dobby.backend.application.mapper
 import com.dobby.backend.infrastructure.database.entity.enum.ProviderType
 import com.dobby.backend.infrastructure.database.entity.enum.RoleType
 import com.dobby.backend.presentation.api.dto.response.MemberResponse
-import com.dobby.backend.presentation.api.dto.response.OauthLoginResponse
+import com.dobby.backend.presentation.api.dto.response.auth.OauthLoginResponse
 
 object OauthUserMapper {
     fun toDto(

--- a/src/main/kotlin/com/dobby/backend/application/mapper/SignupMapper.kt
+++ b/src/main/kotlin/com/dobby/backend/application/mapper/SignupMapper.kt
@@ -10,7 +10,7 @@ import com.dobby.backend.infrastructure.database.entity.AddressInfo as AddressIn
 import com.dobby.backend.presentation.api.dto.request.AddressInfo as DtoAddressInfo
 
 object SignupMapper {
-    fun toAddressInfoDto(dto: DtoAddressInfo): AddressInfo {
+    fun toAddressInfo(dto: DtoAddressInfo): AddressInfo {
         return AddressInfo(
             dto.region,
             dto.area
@@ -34,8 +34,8 @@ object SignupMapper {
     ): ParticipantEntity {
         return ParticipantEntity(
             member = member,
-            basicAddressInfo = toAddressInfoDto(req.basicAddressInfo),
-            additionalAddressInfo = req.additionalAddressInfo?.let { toAddressInfoDto(it) },
+            basicAddressInfo = toAddressInfo(req.basicAddressInfo),
+            additionalAddressInfo = req.additionalAddressInfo?.let { toAddressInfo(it) },
             preferType = req.preferType,
             gender = req.gender
         )

--- a/src/main/kotlin/com/dobby/backend/application/mapper/SignupMapper.kt
+++ b/src/main/kotlin/com/dobby/backend/application/mapper/SignupMapper.kt
@@ -1,0 +1,43 @@
+package com.dobby.backend.application.mapper
+
+import com.dobby.backend.infrastructure.database.entity.MemberEntity
+import com.dobby.backend.infrastructure.database.entity.ParticipantEntity
+import com.dobby.backend.infrastructure.database.entity.enum.MemberStatus
+import com.dobby.backend.infrastructure.database.entity.enum.RoleType
+import com.dobby.backend.presentation.api.dto.request.ParticipantSignupRequest
+import com.dobby.backend.presentation.api.dto.response.MemberResponse
+import com.dobby.backend.infrastructure.database.entity.AddressInfo as AddressInfo
+import com.dobby.backend.presentation.api.dto.request.AddressInfo as DtoAddressInfo
+
+object SignupMapper {
+    fun toAddressInfoDto(dto: DtoAddressInfo): AddressInfo {
+        return AddressInfo(
+            dto.region,
+            dto.area
+        )
+    }
+    fun toMember(req: ParticipantSignupRequest): MemberEntity {
+        return MemberEntity(
+            id = 0, // Auto-generated
+            oauthEmail = req.oauthEmail,
+            provider = req.provider,
+            status = MemberStatus.ACTIVE,
+            role = RoleType.PARTICIPANT,
+            contactEmail = req.contactEmail,
+            name = req.name,
+            birthDate = req.birthDate
+        )
+    }
+    fun toParticipant(
+        member: MemberEntity,
+        req: ParticipantSignupRequest
+    ): ParticipantEntity {
+        return ParticipantEntity(
+            member = member,
+            basicAddressInfo = toAddressInfoDto(req.basicAddressInfo),
+            additionalAddressInfo = req.additionalAddressInfo?.let { toAddressInfoDto(it) },
+            preferType = req.preferType,
+            gender = req.gender
+        )
+    }
+}

--- a/src/main/kotlin/com/dobby/backend/application/service/OauthService.kt
+++ b/src/main/kotlin/com/dobby/backend/application/service/OauthService.kt
@@ -2,7 +2,7 @@ package com.dobby.backend.application.service
 
 import com.dobby.backend.application.usecase.FetchGoogleUserInfoUseCase
 import com.dobby.backend.presentation.api.dto.request.OauthLoginRequest
-import com.dobby.backend.presentation.api.dto.response.OauthLoginResponse
+import com.dobby.backend.presentation.api.dto.response.auth.OauthLoginResponse
 import org.springframework.stereotype.Service
 
 @Service

--- a/src/main/kotlin/com/dobby/backend/application/service/SignupService.kt
+++ b/src/main/kotlin/com/dobby/backend/application/service/SignupService.kt
@@ -1,0 +1,15 @@
+package com.dobby.backend.application.service
+
+import com.dobby.backend.application.usecase.ParticipantSignupUseCase
+import com.dobby.backend.presentation.api.dto.request.ParticipantSignupRequest
+import com.dobby.backend.presentation.api.dto.response.signup.SignupResponse
+import org.springframework.stereotype.Service
+
+@Service
+class SignupService(
+    private val participantSignupUseCase: ParticipantSignupUseCase
+) {
+    fun participantSignup(input: ParticipantSignupRequest): SignupResponse {
+        return participantSignupUseCase.execute(input)
+    }
+}

--- a/src/main/kotlin/com/dobby/backend/application/service/SignupService.kt
+++ b/src/main/kotlin/com/dobby/backend/application/service/SignupService.kt
@@ -3,12 +3,14 @@ package com.dobby.backend.application.service
 import com.dobby.backend.application.usecase.ParticipantSignupUseCase
 import com.dobby.backend.presentation.api.dto.request.ParticipantSignupRequest
 import com.dobby.backend.presentation.api.dto.response.signup.SignupResponse
+import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
 
 @Service
 class SignupService(
     private val participantSignupUseCase: ParticipantSignupUseCase
 ) {
+    @Transactional
     fun participantSignup(input: ParticipantSignupRequest): SignupResponse {
         return participantSignupUseCase.execute(input)
     }

--- a/src/main/kotlin/com/dobby/backend/application/usecase/FetchGoogleUserInfoUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/FetchGoogleUserInfoUseCase.kt
@@ -2,7 +2,6 @@ package com.dobby.backend.application.usecase
 
 import com.dobby.backend.application.mapper.OauthUserMapper
 import com.dobby.backend.domain.exception.OAuth2EmailNotFoundException
-import com.dobby.backend.domain.exception.OAuth2ProviderMissingException
 import com.dobby.backend.domain.exception.SignInMemberException
 import com.dobby.backend.infrastructure.config.properties.GoogleAuthProperties
 import com.dobby.backend.infrastructure.database.entity.enum.MemberStatus
@@ -16,10 +15,7 @@ import com.dobby.backend.presentation.api.dto.request.OauthLoginRequest
 import com.dobby.backend.presentation.api.dto.response.auth.google.GoogleTokenResponse
 import com.dobby.backend.presentation.api.dto.response.auth.OauthLoginResponse
 import com.dobby.backend.util.AuthenticationUtils
-import feign.FeignException
-import org.springframework.stereotype.Component
 
-@Component
 class FetchGoogleUserInfoUseCase(
     private val googleAuthFeignClient: GoogleAuthFeignClient,
     private val googleUserInfoFeginClient: GoogleUserInfoFeginClient,

--- a/src/main/kotlin/com/dobby/backend/application/usecase/FetchGoogleUserInfoUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/FetchGoogleUserInfoUseCase.kt
@@ -13,8 +13,8 @@ import com.dobby.backend.infrastructure.feign.GoogleUserInfoFeginClient
 import com.dobby.backend.infrastructure.token.JwtTokenProvider
 import com.dobby.backend.presentation.api.dto.request.GoogleTokenRequest
 import com.dobby.backend.presentation.api.dto.request.OauthLoginRequest
-import com.dobby.backend.presentation.api.dto.response.GoogleTokenResponse
-import com.dobby.backend.presentation.api.dto.response.OauthLoginResponse
+import com.dobby.backend.presentation.api.dto.response.auth.google.GoogleTokenResponse
+import com.dobby.backend.presentation.api.dto.response.auth.OauthLoginResponse
 import com.dobby.backend.util.AuthenticationUtils
 import feign.FeignException
 import org.springframework.stereotype.Component
@@ -58,8 +58,8 @@ class FetchGoogleUserInfoUseCase(
                 role = regMember.role ?: throw SignInMemberException(),
                 provider = ProviderType.GOOGLE
             )
-        } catch (e: FeignException) {
-            throw OAuth2ProviderMissingException()
+        } catch (e: SignInMemberException) {
+            throw SignInMemberException()
         }
     }
 

--- a/src/main/kotlin/com/dobby/backend/application/usecase/ParticipantSignupUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/ParticipantSignupUseCase.kt
@@ -16,7 +16,6 @@ class ParticipantSignupUseCase (
     private val jwtTokenProvider: JwtTokenProvider
 ):UseCase<ParticipantSignupRequest, SignupResponse>
 {
-    @Transactional
     override fun execute(input: ParticipantSignupRequest): SignupResponse {
         val memberEntity = SignupMapper.toMember(input)
         val participantEntity = SignupMapper.toParticipant(memberEntity, input)

--- a/src/main/kotlin/com/dobby/backend/application/usecase/ParticipantSignupUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/ParticipantSignupUseCase.kt
@@ -7,10 +7,7 @@ import com.dobby.backend.presentation.api.dto.request.ParticipantSignupRequest
 import com.dobby.backend.presentation.api.dto.response.MemberResponse
 import com.dobby.backend.presentation.api.dto.response.signup.SignupResponse
 import com.dobby.backend.util.AuthenticationUtils
-import jakarta.transaction.Transactional
-import org.springframework.stereotype.Component
 
-@Component
 class ParticipantSignupUseCase (
     private val participantRepository: ParticipantRepository,
     private val jwtTokenProvider: JwtTokenProvider

--- a/src/main/kotlin/com/dobby/backend/application/usecase/ParticipantSignupUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/ParticipantSignupUseCase.kt
@@ -22,9 +22,9 @@ class ParticipantSignupUseCase (
         val participantEntity = SignupMapper.toParticipant(memberEntity, input)
 
         val newParticipant = participantRepository.save(participantEntity)
-
-        val accessToken = jwtTokenProvider.generateAccessToken(AuthenticationUtils.createAuthentication(memberEntity))
-        val refreshToken = jwtTokenProvider.generateRefreshToken(AuthenticationUtils.createAuthentication(memberEntity))
+        val authentication = AuthenticationUtils.createAuthentication(memberEntity)
+        val accessToken = jwtTokenProvider.generateAccessToken(authentication)
+        val refreshToken = jwtTokenProvider.generateRefreshToken(authentication)
 
         return SignupResponse(
             memberInfo = MemberResponse.fromDomain(newParticipant.member.toDomain()),

--- a/src/main/kotlin/com/dobby/backend/application/usecase/ParticipantSignupUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/ParticipantSignupUseCase.kt
@@ -1,0 +1,35 @@
+package com.dobby.backend.application.usecase
+
+import com.dobby.backend.application.mapper.SignupMapper
+import com.dobby.backend.infrastructure.database.repository.ParticipantRepository
+import com.dobby.backend.infrastructure.token.JwtTokenProvider
+import com.dobby.backend.presentation.api.dto.request.ParticipantSignupRequest
+import com.dobby.backend.presentation.api.dto.response.MemberResponse
+import com.dobby.backend.presentation.api.dto.response.signup.SignupResponse
+import com.dobby.backend.util.AuthenticationUtils
+import jakarta.transaction.Transactional
+import org.springframework.stereotype.Component
+
+@Component
+class ParticipantSignupUseCase (
+    private val participantRepository: ParticipantRepository,
+    private val jwtTokenProvider: JwtTokenProvider
+):UseCase<ParticipantSignupRequest, SignupResponse>
+{
+    @Transactional
+    override fun execute(input: ParticipantSignupRequest): SignupResponse {
+        val memberEntity = SignupMapper.toMember(input)
+        val participantEntity = SignupMapper.toParticipant(memberEntity, input)
+
+        val newParticipant = participantRepository.save(participantEntity)
+
+        val accessToken = jwtTokenProvider.generateAccessToken(AuthenticationUtils.createAuthentication(memberEntity))
+        val refreshToken = jwtTokenProvider.generateRefreshToken(AuthenticationUtils.createAuthentication(memberEntity))
+
+        return SignupResponse(
+            memberInfo = MemberResponse.fromDomain(newParticipant.member.toDomain()),
+            accessToken = accessToken,
+            refreshToken = refreshToken
+        )
+    }
+}

--- a/src/main/kotlin/com/dobby/backend/domain/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/exception/ErrorCode.kt
@@ -47,6 +47,7 @@ enum class ErrorCode(
      * Signup error codes
      */
     SIGNUP_ALREADY_MEMBER("SIGN_UP_001", "You've already joined", HttpStatus.CONFLICT),
+    SIGNUP_UNSUPPORTED_ROLE("SIGN_UP_002", "Requested RoleType does not supported", HttpStatus.BAD_REQUEST),
 
     /**
      * Signin error codes

--- a/src/main/kotlin/com/dobby/backend/domain/exception/MemberException.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/exception/MemberException.kt
@@ -7,3 +7,4 @@ open class MemberException(
 class MemberNotFoundException : MemberException(ErrorCode.MEMBER_NOT_FOUND)
 class AlreadyMemberException: MemberException(ErrorCode.SIGNUP_ALREADY_MEMBER)
 class SignInMemberException: MemberException(ErrorCode.SIGNIN_MEMBER_NOT_FOUND)
+class RoleUnsupportedException: MemberException(ErrorCode.SIGNUP_UNSUPPORTED_ROLE)

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/ParticipantEntity.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/ParticipantEntity.kt
@@ -12,7 +12,7 @@ import java.time.LocalDate
 @Entity(name = "participant")
 @DiscriminatorValue("PARTICIPANT")
 class ParticipantEntity (
-    @OneToOne
+    @OneToOne(cascade = [CascadeType.ALL], orphanRemoval = true)
     @JoinColumn(name = "member_id", nullable = false)
     val member: MemberEntity,
 
@@ -20,38 +20,42 @@ class ParticipantEntity (
     @Enumerated(EnumType.STRING)
     val gender: GenderType,
 
-    @Column(name = "basic_region", nullable = false)
-    @Enumerated(EnumType.STRING)
-    var basicRegion: Region,
+    @Embedded
+    @AttributeOverrides(
+        AttributeOverride(name = "region", column = Column(name = "basic_region", nullable = false)),
+        AttributeOverride(name = "area", column = Column(name = "basic_area", nullable = false))
+    )
+    val basicAddressInfo: AddressInfo,
 
-    @Column(name = "basic_area", nullable = false)
-    @Enumerated(EnumType.STRING)
-    var basicArea : Area,
-
-    @Column(name = "optional_region", nullable = true)
-    @Enumerated(EnumType.STRING)
-    var optionalRegion: Region?,
-
-    @Column(name = "optional_area", nullable = true)
-    @Enumerated(EnumType.STRING)
-    var optionalArea: Area?,
+    @Embedded
+    @AttributeOverrides(
+        AttributeOverride(name = "region", column = Column(name = "optional_region", nullable = true)),
+        AttributeOverride(name = "area", column = Column(name = "optional_area", nullable = true))
+    )
+    val additionalAddressInfo: AddressInfo?,
 
     @Column(name = "prefer_type", nullable = true)
     @Enumerated(EnumType.STRING)
     var preferType: MatchType?,
 
-    id: Long,
-    oauthEmail: String,
-    provider: ProviderType,
-    contactEmail: String,
-    name: String,
-    birthDate: LocalDate
 ) : MemberEntity(
-    id= id,
-    oauthEmail = oauthEmail,
-    provider = provider,
-    contactEmail= contactEmail,
+    id= member.id,
+    oauthEmail = member.oauthEmail,
+    provider = member.provider,
+    contactEmail= member.contactEmail,
     role = RoleType.PARTICIPANT,
-    name = name,
-    birthDate = birthDate
+    name = member.name,
+    birthDate = member.birthDate
 )
+
+@Embeddable
+data class AddressInfo(
+    @Enumerated(EnumType.STRING)
+    @Column(name = "region", nullable = false)
+    val region: Region,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "area", nullable = false)
+    val area: Area
+)
+

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/ResearcherEntity.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/ResearcherEntity.kt
@@ -8,7 +8,7 @@ import java.time.LocalDate
 @Entity(name = "researcher")
 @DiscriminatorValue("RESEARCHER")
 class ResearcherEntity (
-    @OneToOne
+    @OneToOne(cascade = [CascadeType.ALL], orphanRemoval = true)
     @JoinColumn(name = "member_id", nullable = false)
     val member: MemberEntity,
 
@@ -26,19 +26,12 @@ class ResearcherEntity (
 
     @Column(name = "lab_info", length = 100, nullable = true)
     val labInfo : String,
-
-    id: Long,
-    oauthEmail: String,
-    provider: ProviderType,
-    contactEmail: String,
-    name: String,
-    birthDate: LocalDate
 ) : MemberEntity(
-    id= id,
-    oauthEmail = oauthEmail,
-    provider = provider,
-    contactEmail= contactEmail,
+    id= member.id,
+    oauthEmail = member.oauthEmail,
+    provider = member.provider,
+    contactEmail= member.contactEmail,
     role = RoleType.RESEARCHER,
-    name = name,
-    birthDate = birthDate
+    name = member.name,
+    birthDate = member.birthDate
 )

--- a/src/main/kotlin/com/dobby/backend/infrastructure/feign/GoogleAuthFeignClient.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/feign/GoogleAuthFeignClient.kt
@@ -1,12 +1,10 @@
 package com.dobby.backend.infrastructure.feign
 
 import com.dobby.backend.presentation.api.dto.request.GoogleTokenRequest
-import com.dobby.backend.presentation.api.dto.response.GoogleTokenResponse
-import feign.Headers
+import com.dobby.backend.presentation.api.dto.response.auth.google.GoogleTokenResponse
 import org.springframework.cloud.openfeign.FeignClient
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestParam
 
 @FeignClient(
     name = "google-auth-feign-client",

--- a/src/main/kotlin/com/dobby/backend/infrastructure/feign/GoogleUserInfoFeginClient.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/feign/GoogleUserInfoFeginClient.kt
@@ -1,10 +1,9 @@
 package com.dobby.backend.infrastructure.feign
 
-import com.dobby.backend.presentation.api.dto.response.GoogleInfoResponse
+import com.dobby.backend.presentation.api.dto.response.auth.google.GoogleInfoResponse
 import org.springframework.cloud.openfeign.FeignClient
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestHeader
 
 @FeignClient(
     name= "google-userinfo-feign-client",

--- a/src/main/kotlin/com/dobby/backend/presentation/api/controller/AuthController.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/controller/AuthController.kt
@@ -3,9 +3,10 @@ package com.dobby.backend.presentation.api.controller
 import com.dobby.backend.application.service.OauthService
 import com.dobby.backend.application.usecase.GenerateTestToken
 import com.dobby.backend.presentation.api.dto.request.OauthLoginRequest
-import com.dobby.backend.presentation.api.dto.response.OauthLoginResponse
+import com.dobby.backend.presentation.api.dto.response.auth.OauthLoginResponse
 import com.dobby.backend.application.usecase.GenerateTokenWithRefreshToken
 import com.dobby.backend.application.usecase.GetMemberById
+import com.dobby.backend.infrastructure.database.entity.enum.RoleType
 import com.dobby.backend.presentation.api.dto.request.MemberRefreshTokenRequest
 import com.dobby.backend.presentation.api.dto.response.MemberResponse
 import com.dobby.backend.presentation.api.dto.response.TestMemberSignInResponse
@@ -41,6 +42,7 @@ class AuthController(
     @PostMapping("/login/google")
     @Operation(summary = "Google OAuth 로그인 API", description = "Google OAuth 로그인 후 인증 정보를 반환합니다")
     fun signInWithGoogle(
+        @RequestParam role : RoleType, // RESEARCHER, PARTICIPANT
         @RequestBody @Valid oauthLoginRequest: OauthLoginRequest
     ): OauthLoginResponse {
         return oauthService.getGoogleUserInfo(oauthLoginRequest)

--- a/src/main/kotlin/com/dobby/backend/presentation/api/controller/SignupController/ParticipantSignupController.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/controller/SignupController/ParticipantSignupController.kt
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.*
 class ParticipantSignupController(
     private val signupService: SignupService
 ) {
-    @PostMapping("/join")
+    @PostMapping("/signup")
     @Operation(
         summary = "참여자 회원가입 API- OAuth 로그인 필수",
         description = "참여자 OAuth 로그인 실패 시, 리다이렉팅하여 참여자 회원가입하는 API입니다."

--- a/src/main/kotlin/com/dobby/backend/presentation/api/controller/SignupController/ParticipantSignupController.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/controller/SignupController/ParticipantSignupController.kt
@@ -1,0 +1,29 @@
+package com.dobby.backend.presentation.api.controller.SignupController
+
+import com.dobby.backend.application.service.SignupService
+import com.dobby.backend.infrastructure.database.entity.enum.RoleType
+import com.dobby.backend.infrastructure.database.entity.enum.RoleType.*
+import com.dobby.backend.presentation.api.dto.request.ParticipantSignupRequest
+import com.dobby.backend.presentation.api.dto.response.signup.SignupResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.*
+
+@Tag(name = "회원가입 API")
+@RestController
+@RequestMapping("/v1/participants")
+class ParticipantSignupController(
+    private val signupService: SignupService
+) {
+    @PostMapping("/join")
+    @Operation(
+        summary = "참여자 회원가입 API- OAuth 로그인 필수",
+        description = "참여자 OAuth 로그인 실패 시, 리다이렉팅하여 참여자 회원가입하는 API입니다."
+    )
+    fun signup(
+        @RequestBody @Valid req: ParticipantSignupRequest
+    ): SignupResponse {
+        return signupService.participantSignup(req)
+    }
+}

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/ParticipantSignupRequest.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/ParticipantSignupRequest.kt
@@ -1,0 +1,49 @@
+package com.dobby.backend.presentation.api.dto.request
+
+import com.dobby.backend.infrastructure.database.entity.enum.GenderType
+import com.dobby.backend.infrastructure.database.entity.enum.MatchType
+import com.dobby.backend.infrastructure.database.entity.enum.ProviderType
+import com.dobby.backend.infrastructure.database.entity.enum.areaInfo.Area
+import com.dobby.backend.infrastructure.database.entity.enum.areaInfo.Region
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+import java.time.LocalDate
+
+data class ParticipantSignupRequest(
+    @Email(message = "OAuth 이메일이 유효하지 않습니다.")
+    @NotBlank(message = "OAuth 이메일은 공백일 수 없습니다.")
+    val oauthEmail: String,
+
+    @NotBlank(message = "OAuth provider은 공백일 수 없습니다.")
+    val provider: ProviderType,
+
+    @Email(message= "연락 받을 이메일이 유효하지 않습니다.")
+    @NotBlank(message = "연락 받을 이메일은 공백일 수 없습니다.")
+    val contactEmail: String,
+
+    @NotBlank(message = "이름은 공백일 수 없습니다.")
+    val name : String,
+
+    @NotBlank(message = "성별은 공백일 수 없습니다.")
+    val gender: GenderType,
+
+    @NotBlank(message = "생년월일은 공백일 수 없습니다.")
+    val birthDate: LocalDate,
+
+    @NotBlank(message = "거주 지역은 공백일 수 없습니다.")
+    var basicAddressInfo: AddressInfo,
+
+    // 추가 활동 정보
+    var additionalAddressInfo: AddressInfo?,
+
+    // 선호 실험 진행 방식
+    var preferType: MatchType,
+)
+
+data class AddressInfo(
+    @NotBlank(message = "시/도 정보는 공백일 수 없습니다.")
+    val region: Region,
+
+    @NotBlank(message = "시/군/구 정보는 공백일 수 없습니다.")
+    val area: Area
+)

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/ParticipantSignupRequest.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/ParticipantSignupRequest.kt
@@ -7,6 +7,9 @@ import com.dobby.backend.infrastructure.database.entity.enum.areaInfo.Area
 import com.dobby.backend.infrastructure.database.entity.enum.areaInfo.Region
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Past
+import org.springframework.format.annotation.DateTimeFormat
 import java.time.LocalDate
 
 data class ParticipantSignupRequest(
@@ -27,7 +30,8 @@ data class ParticipantSignupRequest(
     @NotBlank(message = "성별은 공백일 수 없습니다.")
     val gender: GenderType,
 
-    @NotBlank(message = "생년월일은 공백일 수 없습니다.")
+    @Past @NotNull(message = "생년월일은 공백일 수 없습니다.")
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
     val birthDate: LocalDate,
 
     @NotBlank(message = "거주 지역은 공백일 수 없습니다.")

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/auth/MemberSignInResponse.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/auth/MemberSignInResponse.kt
@@ -1,5 +1,6 @@
-package com.dobby.backend.presentation.api.dto.response
+package com.dobby.backend.presentation.api.dto.response.auth
 
+import com.dobby.backend.presentation.api.dto.response.MemberResponse
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "로그인 결과 DTO")

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/auth/OauthLoginResponse.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/auth/OauthLoginResponse.kt
@@ -1,5 +1,6 @@
-package com.dobby.backend.presentation.api.dto.response
+package com.dobby.backend.presentation.api.dto.response.auth
 
+import com.dobby.backend.presentation.api.dto.response.MemberResponse
 import io.swagger.v3.oas.annotations.media.Schema
 import lombok.Getter
 

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/auth/google/GoogleInfoResponse.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/auth/google/GoogleInfoResponse.kt
@@ -1,4 +1,4 @@
-package com.dobby.backend.presentation.api.dto.response
+package com.dobby.backend.presentation.api.dto.response.auth.google
 
 import com.fasterxml.jackson.annotation.JsonProperty
 

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/auth/google/GoogleTokenResponse.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/auth/google/GoogleTokenResponse.kt
@@ -1,4 +1,4 @@
-package com.dobby.backend.presentation.api.dto.response
+package com.dobby.backend.presentation.api.dto.response.auth.google
 
 import com.fasterxml.jackson.annotation.JsonProperty
 

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/signup/ParticipantSignupResponse.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/signup/ParticipantSignupResponse.kt
@@ -1,0 +1,15 @@
+package com.dobby.backend.presentation.api.dto.response.signup
+
+import com.dobby.backend.presentation.api.dto.response.MemberResponse
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class SignupResponse(
+    @Schema(description = "실험자 회원가입 후 발급되는 Access Token")
+    val accessToken: String,
+
+    @Schema(description = "실험자 회원가입 후 발급되는 Refresh Token")
+    val refreshToken: String,
+
+    @Schema(description = "실험자 회원가입 정보")
+    val memberInfo: MemberResponse
+)

--- a/src/test/kotlin/com/dobby/backend/application/mapper/SignupMapperTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/mapper/SignupMapperTest.kt
@@ -1,0 +1,75 @@
+package com.dobby.backend.application.mapper
+
+import com.dobby.backend.infrastructure.database.entity.enum.*
+import com.dobby.backend.infrastructure.database.entity.enum.areaInfo.Area
+import com.dobby.backend.infrastructure.database.entity.enum.areaInfo.Region
+import com.dobby.backend.presentation.api.dto.request.ParticipantSignupRequest
+import org.springframework.test.context.ActiveProfiles
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import java.time.LocalDate
+import com.dobby.backend.presentation.api.dto.request.AddressInfo as DtoAddressInfo
+
+@ActiveProfiles("test")
+class SignupMapperTest : BehaviorSpec({
+    given("주소 dto를 AddressInfo 엔티티로 변환할 때") {
+        `when`("toAddressInfoDto 메서드가 호출되면") {
+            val dtoAddressInfo = DtoAddressInfo(region = Region.SEOUL, area = Area.SEOUL_ALL)
+            val result = SignupMapper.toAddressInfoDto(dtoAddressInfo)
+
+            then("올바른 AddressInfo 객체가 반환되어야 한다") {
+                result.region shouldBe Region.SEOUL
+                result.area shouldBe Area.SEOUL_ALL
+            }
+        }
+
+        `when`("toMember 메서드가 호출되면") {
+            val request = ParticipantSignupRequest(
+                oauthEmail = "test@example.com",
+                provider = ProviderType.GOOGLE,
+                contactEmail = "contact@example.com",
+                name = "Test User",
+                birthDate = LocalDate.of(2002, 11, 21),
+                basicAddressInfo = DtoAddressInfo(region = Region.SEOUL, area = Area.SEOUL_ALL),
+                additionalAddressInfo = null,
+                preferType = MatchType.HYBRID,
+                gender = GenderType.FEMALE
+            )
+            val result = SignupMapper.toMember(request)
+
+            then("올바른 MemberEntity 객체가 반환되어야 한다") {
+                result.oauthEmail shouldBe "test@example.com"
+                result.provider shouldBe ProviderType.GOOGLE
+                result.contactEmail shouldBe "contact@example.com"
+                result.name shouldBe "Test User"
+                result.birthDate shouldBe LocalDate.of(2002, 11, 21)
+                result.role shouldBe RoleType.PARTICIPANT
+                result.status shouldBe MemberStatus.ACTIVE
+            }
+        }
+
+        `when`("toParticipant 메서드가 호출되면") {
+            val request = ParticipantSignupRequest(
+                oauthEmail = "test@example.com",
+                provider = ProviderType.GOOGLE,
+                contactEmail = "contact@example.com",
+                name = "Test User",
+                birthDate = LocalDate.of(2002, 11, 21),
+                basicAddressInfo = DtoAddressInfo(region = Region.SEOUL, area = Area.SEOUL_ALL),
+                additionalAddressInfo = DtoAddressInfo(region = Region.GYEONGGI, area = Area.GWANGMYEONGSI),
+                preferType = MatchType.HYBRID,
+                gender = GenderType.FEMALE
+            )
+            val member = SignupMapper.toMember(request)
+            val result = SignupMapper.toParticipant(member, request)
+
+            then("올바른 ParticipantEntity 객체가 반환되어야 한다") {
+                result.member.oauthEmail shouldBe "test@example.com"
+                result.basicAddressInfo.region shouldBe Region.SEOUL
+                result.basicAddressInfo.area shouldBe Area.SEOUL_ALL
+                result.additionalAddressInfo?.region shouldBe Region.GYEONGGI
+                result.additionalAddressInfo?.area shouldBe Area.GWANGMYEONGSI
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/dobby/backend/application/mapper/SignupMapperTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/mapper/SignupMapperTest.kt
@@ -15,7 +15,7 @@ class SignupMapperTest : BehaviorSpec({
     given("주소 dto를 AddressInfo 엔티티로 변환할 때") {
         `when`("toAddressInfoDto 메서드가 호출되면") {
             val dtoAddressInfo = DtoAddressInfo(region = Region.SEOUL, area = Area.SEOUL_ALL)
-            val result = SignupMapper.toAddressInfoDto(dtoAddressInfo)
+            val result = SignupMapper.toAddressInfo(dtoAddressInfo)
 
             then("올바른 AddressInfo 객체가 반환되어야 한다") {
                 result.region shouldBe Region.SEOUL

--- a/src/test/kotlin/com/dobby/backend/application/service/OauthServiceTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/service/OauthServiceTest.kt
@@ -4,7 +4,7 @@ import com.dobby.backend.infrastructure.database.entity.enum.ProviderType
 import com.dobby.backend.infrastructure.database.entity.enum.RoleType
 import com.dobby.backend.presentation.api.dto.request.OauthLoginRequest
 import com.dobby.backend.presentation.api.dto.response.MemberResponse
-import com.dobby.backend.presentation.api.dto.response.OauthLoginResponse
+import com.dobby.backend.presentation.api.dto.response.auth.OauthLoginResponse
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every

--- a/src/test/kotlin/com/dobby/backend/application/usecase/FetchGoogleUserInfoTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/FetchGoogleUserInfoTest.kt
@@ -9,7 +9,7 @@ import com.dobby.backend.infrastructure.feign.GoogleAuthFeignClient
 import com.dobby.backend.infrastructure.feign.GoogleUserInfoFeginClient
 import com.dobby.backend.infrastructure.token.JwtTokenProvider
 import com.dobby.backend.presentation.api.dto.request.OauthLoginRequest
-import com.dobby.backend.presentation.api.dto.response.GoogleTokenResponse
+import com.dobby.backend.presentation.api.dto.response.auth.google.GoogleTokenResponse
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every

--- a/src/test/kotlin/com/dobby/backend/application/usecase/ParticipantSignupUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/ParticipantSignupUseCaseTest.kt
@@ -1,0 +1,64 @@
+package com.dobby.backend.application.usecase
+
+import com.dobby.backend.application.mapper.SignupMapper
+import com.dobby.backend.infrastructure.database.entity.ParticipantEntity
+import com.dobby.backend.infrastructure.database.entity.enum.GenderType
+import com.dobby.backend.infrastructure.database.entity.enum.MatchType
+import com.dobby.backend.infrastructure.database.entity.enum.areaInfo.Area
+import com.dobby.backend.infrastructure.database.entity.enum.areaInfo.Region
+import com.dobby.backend.infrastructure.database.repository.ParticipantRepository
+import com.dobby.backend.infrastructure.token.JwtTokenProvider
+import com.dobby.backend.presentation.api.dto.request.ParticipantSignupRequest
+import com.dobby.backend.presentation.api.dto.request.AddressInfo as DtoAddressInfo
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.time.LocalDate
+
+class ParticipantSignupUseCaseTest : BehaviorSpec({
+
+    given("유효한 ParticipantSignupRequest가 주어졌을 때") {
+        val participantRepository = mockk<ParticipantRepository>()
+        val jwtTokenProvider = mockk<JwtTokenProvider>()
+        val useCase = ParticipantSignupUseCase(participantRepository, jwtTokenProvider)
+
+        val request = ParticipantSignupRequest(
+            oauthEmail = "test@example.com",
+            provider = com.dobby.backend.infrastructure.database.entity.enum.ProviderType.GOOGLE,
+            contactEmail = "contact@example.com",
+            name = "Test User",
+            birthDate = LocalDate.of(2002, 11, 21),
+            basicAddressInfo = DtoAddressInfo(region = Region.SEOUL, area = Area.SEOUL_ALL),
+            additionalAddressInfo = null,
+            preferType = MatchType.HYBRID,
+            gender = GenderType.FEMALE
+        )
+
+        val member = SignupMapper.toMember(request)
+        val participant = SignupMapper.toParticipant(member, request)
+
+        every { participantRepository.save(any<ParticipantEntity>()) } returns participant
+        every { jwtTokenProvider.generateAccessToken(any()) } returns "mock-access-token"
+        every { jwtTokenProvider.generateRefreshToken(any()) } returns "mock-refresh-token"
+
+        `when`("ParticipantSignupUseCase가 실행되면") {
+            val response = useCase.execute(request)
+
+            then("ParticipantRepository에 엔티티가 저장되고, SignupResponse가 반환되어야 한다") {
+                response.accessToken shouldBe "mock-access-token"
+                response.refreshToken shouldBe "mock-refresh-token"
+                response.memberInfo.oauthEmail shouldBe "test@example.com"
+                response.memberInfo.name shouldBe "Test User"
+
+                // 엔티티 저장
+                verify(exactly = 1) { participantRepository.save(any<ParticipantEntity>()) }
+
+                // JWT 토큰 발급
+                verify(exactly = 1) { jwtTokenProvider.generateAccessToken(any()) }
+                verify(exactly = 1) { jwtTokenProvider.generateRefreshToken(any()) }
+            }
+        }
+    }
+})


### PR DESCRIPTION
## 💡 작업 내용
- 실험자(`Participant`) 회원가입 API 구현

> 밑의 다이어그램을 바탕으로 로직을 구현했습니다. 
지금의 PR은 빨간 색 윤곽선에 해당되는 플로우를 구현한 것으로 보시면 될 것 같습니다. 

![image](https://github.com/user-attachments/assets/dfa55618-95c8-4185-9e77-7235554f6a66)
(현재 API 엔드포인트가 쿼리 스트링이랑 리소스 방식이 혼재되어있어서, 관련해서 이야기 나눠보면 좋을 것 같아요) 

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- 관련된 Discussion 등이 있다면 첨부해주세요


## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-67