### PR TITLE
[YS-117] feat: 특정 실험 공고 참여 방법 조회 API 구현

### DIFF
--- a/src/main/kotlin/com/dobby/backend/application/service/ExperimentPostService.kt
+++ b/src/main/kotlin/com/dobby/backend/application/service/ExperimentPostService.kt
@@ -1,6 +1,7 @@
 package com.dobby.backend.application.service
 
 import com.dobby.backend.application.usecase.experiment.CreateExperimentPostUseCase
+import com.dobby.backend.application.usecase.experiment.GetExperimentPostApplyMethodUseCase
 import com.dobby.backend.application.usecase.experiment.GetExperimentPostDetailUseCase
 import com.dobby.backend.application.usecase.experiment.GetResearcherInfoUseCase
 import jakarta.transaction.Transactional
@@ -10,7 +11,8 @@ import org.springframework.stereotype.Service
 class ExperimentPostService(
     private val createExperimentPostUseCase: CreateExperimentPostUseCase,
     private val getResearcherInfoUseCase: GetResearcherInfoUseCase,
-    private val getExperimentPostDetailUseCase: GetExperimentPostDetailUseCase
+    private val getExperimentPostDetailUseCase: GetExperimentPostDetailUseCase,
+    private val getExperimentPostApplyMethodUseCase: GetExperimentPostApplyMethodUseCase,
 ) {
     @Transactional
     fun createNewExperimentPost(input: CreateExperimentPostUseCase.Input): CreateExperimentPostUseCase.Output {
@@ -23,5 +25,9 @@ class ExperimentPostService(
 
     fun getExperimentPostDetail(input: GetExperimentPostDetailUseCase.Input): GetExperimentPostDetailUseCase.Output {
         return getExperimentPostDetailUseCase.execute(input)
+    }
+
+    fun getExperimentPostApplyMethod(input: GetExperimentPostApplyMethodUseCase.Input): GetExperimentPostApplyMethodUseCase.Output {
+        return getExperimentPostApplyMethodUseCase.execute(input)
     }
 }

--- a/src/main/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostApplyMethodUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostApplyMethodUseCase.kt
@@ -1,0 +1,33 @@
+package com.dobby.backend.application.usecase.experiment
+
+import com.dobby.backend.application.usecase.UseCase
+import com.dobby.backend.domain.exception.ExperimentPostNotFoundException
+import com.dobby.backend.domain.gateway.ExperimentPostGateway
+
+class GetExperimentPostApplyMethodUseCase(
+    private val experimentPostGateway: ExperimentPostGateway,
+): UseCase<GetExperimentPostApplyMethodUseCase.Input, GetExperimentPostApplyMethodUseCase.Output> {
+
+    data class Input(
+        val experimentPostId: Long
+    )
+
+    data class Output(
+        val applyMethodId: Long,
+        val phoneNum: String?,
+        val formUrl: String?,
+        val content: String
+    )
+
+    override fun execute(input: Input): Output {
+        val experimentPost = experimentPostGateway.findById(input.experimentPostId)
+            ?: throw ExperimentPostNotFoundException()
+
+        return Output(
+            applyMethodId = experimentPost.applyMethod.id,
+            phoneNum = experimentPost.applyMethod.phoneNum,
+            formUrl = experimentPost.applyMethod.formUrl,
+            content = experimentPost.applyMethod.content
+        )
+    }
+}

--- a/src/main/kotlin/com/dobby/backend/presentation/api/controller/ExperimentPostController.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/controller/ExperimentPostController.kt
@@ -4,6 +4,7 @@ import com.dobby.backend.application.service.ExperimentPostService
 import com.dobby.backend.presentation.api.dto.request.expirement.CreateExperimentPostRequest
 import com.dobby.backend.presentation.api.dto.response.expirement.CreateExperimentPostResponse
 import com.dobby.backend.presentation.api.dto.response.expirement.DefaultInfoResponse
+import com.dobby.backend.presentation.api.dto.response.expirement.ExperimentPostApplyMethodResponse
 import com.dobby.backend.presentation.api.dto.response.expirement.ExperimentPostDetailResponse
 import com.dobby.backend.presentation.api.mapper.ExperimentPostMapper
 import io.swagger.v3.oas.annotations.Operation
@@ -55,5 +56,18 @@ class ExperimentPostController (
         val input = ExperimentPostMapper.toGetExperimentPostDetailUseCaseInput(postId)
         val output = experimentPostService.getExperimentPostDetail(input)
         return ExperimentPostMapper.toGetExperimentPostDetailResponse(output)
+    }
+
+    @GetMapping("/{postId}/apply-method")
+    @Operation(
+        summary = "특정 공고 지원 방법 조회",
+        description = "특정 공고의 지원 방법을 반환합니다."
+    )
+    fun getExperimentPostApplyMethod(
+        @PathVariable postId: Long
+    ): ExperimentPostApplyMethodResponse {
+        val input = ExperimentPostMapper.toGetExperimentPostApplyMethodUseCaseInput(postId)
+        val output = experimentPostService.getExperimentPostApplyMethod(input)
+        return ExperimentPostMapper.toGetExperimentPostApplyMethodResponse(output)
     }
 }

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/expirement/ExperimentPostApplyMethodResponse.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/expirement/ExperimentPostApplyMethodResponse.kt
@@ -1,0 +1,18 @@
+package com.dobby.backend.presentation.api.dto.response.expirement
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "실험 공고 참여 방법 조회 응답 DTO")
+data class ExperimentPostApplyMethodResponse(
+    @Schema(description = "참여 방법 Id", example = "1")
+    val applyMethodId: Long,
+
+    @Schema(description = "전화번호", example = "010-1234-5678")
+    val phoneNum: String?,
+
+    @Schema(description = "신청서 URL", example = "https://form.com")
+    val formUrl: String?,
+
+    @Schema(description = "참여 방법 내용", example = "해당 전화번호로 연락주세요.")
+    val content: String
+)

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/expirement/ExperimentPostDetailResponse.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/expirement/ExperimentPostDetailResponse.kt
@@ -40,7 +40,7 @@ data class ExperimentPostDetailResponse(
     @Schema(description = "내용", example = "실험 게시물 내용입니다.")
     val content: String,
 
-    @Schema(description = "이미지 목록", example = "[\"https://bucket/image1.wep\", \"https://bucket/image2.wep\"]")
+    @Schema(description = "이미지 목록", example = "[\"https://bucket/image1.webp\", \"https://bucket/image2.webp\"]")
     val imageList: List<String>
 ) {
     @Schema(description = "실험 공고 요약 정보")

--- a/src/main/kotlin/com/dobby/backend/presentation/api/mapper/ExperimentPostMapper.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/mapper/ExperimentPostMapper.kt
@@ -1,13 +1,11 @@
 package com.dobby.backend.presentation.api.mapper
 
 import com.dobby.backend.application.usecase.experiment.CreateExperimentPostUseCase
+import com.dobby.backend.application.usecase.experiment.GetExperimentPostApplyMethodUseCase
 import com.dobby.backend.application.usecase.experiment.GetExperimentPostDetailUseCase
 import com.dobby.backend.application.usecase.experiment.GetResearcherInfoUseCase
 import com.dobby.backend.presentation.api.dto.request.expirement.CreateExperimentPostRequest
-import com.dobby.backend.presentation.api.dto.response.expirement.CreateExperimentPostResponse
-import com.dobby.backend.presentation.api.dto.response.expirement.DefaultInfoResponse
-import com.dobby.backend.presentation.api.dto.response.expirement.ExperimentPostDetailResponse
-import com.dobby.backend.presentation.api.dto.response.expirement.PostInfo
+import com.dobby.backend.presentation.api.dto.response.expirement.*
 import com.dobby.backend.util.getCurrentMemberId
 
 object ExperimentPostMapper {
@@ -107,6 +105,21 @@ object ExperimentPostMapper {
             address = response.experimentPostDetailResponse.address,
             content = response.experimentPostDetailResponse.content,
             imageList = response.experimentPostDetailResponse.imageList
+        )
+    }
+
+    fun toGetExperimentPostApplyMethodUseCaseInput(experimentPostId: Long): GetExperimentPostApplyMethodUseCase.Input {
+        return GetExperimentPostApplyMethodUseCase.Input(
+            experimentPostId = experimentPostId
+        )
+    }
+
+    fun toGetExperimentPostApplyMethodResponse(output: GetExperimentPostApplyMethodUseCase.Output): ExperimentPostApplyMethodResponse {
+        return ExperimentPostApplyMethodResponse(
+            applyMethodId = output.applyMethodId,
+            phoneNum = output.phoneNum,
+            formUrl = output.formUrl,
+            content = output.content
         )
     }
 }

--- a/src/test/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostApplyMethodUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostApplyMethodUseCaseTest.kt
@@ -1,0 +1,92 @@
+package com.dobby.backend.application.usecase.experiment
+
+import com.dobby.backend.domain.exception.ExperimentPostNotFoundException
+import com.dobby.backend.domain.gateway.ExperimentPostGateway
+import com.dobby.backend.domain.model.experiment.ApplyMethod
+import com.dobby.backend.domain.model.experiment.ExperimentPost
+import com.dobby.backend.domain.model.experiment.TargetGroup
+import com.dobby.backend.domain.model.member.Member
+import com.dobby.backend.infrastructure.database.entity.enum.MatchType
+import com.dobby.backend.infrastructure.database.entity.enum.TimeSlot
+import com.dobby.backend.infrastructure.database.entity.enum.areaInfo.Area
+import com.dobby.backend.infrastructure.database.entity.enum.areaInfo.Region
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.assertions.throwables.shouldThrow
+import io.mockk.every
+import io.mockk.mockk
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class GetExperimentPostApplyMethodUseCaseTest : BehaviorSpec({
+    val experimentPostGateway = mockk<ExperimentPostGateway>()
+    val useCase = GetExperimentPostApplyMethodUseCase(experimentPostGateway)
+
+    given("유효한 experimentPostId가 주어졌을 때") {
+        val experimentPostId = 1L
+
+        val member = mockk<Member>()
+        val targetGroup = mockk<TargetGroup>()
+        val applyMethod = ApplyMethod(
+            id = 1L,
+            phoneNum = "123-456-7890",
+            formUrl = "https://example.com",
+            content = "지원 방법에 대한 상세 설명"
+        )
+        val mockExperimentPost = ExperimentPost(
+            id = experimentPostId,
+            title = "야뿌들의 평균 식사량 체크 테스트",
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now(),
+            member = member,
+            views = 100,
+            recruitDone = false,
+            startDate = LocalDate.now(),
+            endDate = LocalDate.now(),
+            leadResearcher = "Lead",
+            matchType = MatchType.HYBRID,
+            reward = "네이버페이 1000원",
+            count = 10,
+            timeRequired = TimeSlot.ABOUT_1H,
+            targetGroup = targetGroup,
+            applyMethod = applyMethod,
+            region = Region.SEOUL,
+            area = Area.GWANGJINGU,
+            univName = "건국대학교",
+            detailedAddress = "건국대학교 공학관",
+            content = "야뿌들의 한끼 식사량을 체크하는 테스트입니다.",
+            alarmAgree = false,
+            images = emptyList()
+        )
+
+        every { experimentPostGateway.findById(experimentPostId) } returns mockExperimentPost
+
+        `when`("useCase의 execute가 호출되면") {
+            val input = GetExperimentPostApplyMethodUseCase.Input(experimentPostId)
+            val result = useCase.execute(input)
+
+            then("applyMethod 정보가 반환된다") {
+                result.applyMethodId shouldBe applyMethod.id
+                result.phoneNum shouldBe applyMethod.phoneNum
+                result.formUrl shouldBe applyMethod.formUrl
+                result.content shouldBe applyMethod.content
+            }
+        }
+    }
+
+    given("존재하지 않는 experimentPostId가 주어졌을 때") {
+        val invalidExperimentPostId = 999L
+
+        every { experimentPostGateway.findById(invalidExperimentPostId) } returns null
+
+        `when`("useCase의 execute가 호출되면") {
+            val input = GetExperimentPostApplyMethodUseCase.Input(invalidExperimentPostId)
+
+            then("ExperimentPostNotFoundException이 발생한다") {
+                shouldThrow<ExperimentPostNotFoundException> {
+                    useCase.execute(input)
+                }
+            }
+        }
+    }
+})

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -40,7 +40,6 @@ app:
       access: 86400
       refresh: 604800
 
-
 cloud:
   aws:
     s3:


### PR DESCRIPTION
## 💡 작업 내용
- 특정 실험 공고의 참여 방법을 조회할 수 있는 API를 구현했습니다
<img width="401" alt="image" src="https://github.com/user-attachments/assets/fc9d492f-bf8d-4391-8ec0-214d4136f3a3" />

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- 관련된 Discussion 등이 있다면 첨부해주세요


## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-117