### PR TITLE
[YS-159] feat: 추가 지역에 대해 선택하지 않은 참여자 지역 정보에 NONE 값 적용

### DIFF
--- a/src/main/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostCountsByRegionUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostCountsByRegionUseCase.kt
@@ -25,7 +25,7 @@ class GetExperimentPostCountsByRegionUseCase(
     override fun execute(input: Input): Output {
         val total = experimentPostGateway.countExperimentPosts()
 
-        val allRegions = Region.values()
+        val allRegions = Region.values().filter { it != Region.NONE }
         val regionData = experimentPostGateway.countExperimentPostGroupedByRegion()
         val regionDataMap = regionData.associateBy { it.get(0, Region::class.java) }
 

--- a/src/main/kotlin/com/dobby/backend/application/usecase/member/CreateParticipantUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/member/CreateParticipantUseCase.kt
@@ -25,7 +25,7 @@ class CreateParticipantUseCase (
         val gender: GenderType,
         val birthDate: LocalDate,
         var basicAddressInfo: AddressInfo,
-        var additionalAddressInfo: AddressInfo?,
+        var additionalAddressInfo: AddressInfo,
         var matchType: MatchType,
     )
     data class AddressInfo(
@@ -86,9 +86,10 @@ class CreateParticipantUseCase (
                 region = input.basicAddressInfo.region,
                 area = input.basicAddressInfo.area
             ),
-            additionalAddressInfo = input.additionalAddressInfo?.let {
-                Participant.AddressInfo(region = it.region, area = it.area)
-            },
+            additionalAddressInfo = Participant.AddressInfo(
+                region = input.additionalAddressInfo.region,
+                area = input.additionalAddressInfo.area
+            ),
             matchType = input.matchType
         )
     }

--- a/src/main/kotlin/com/dobby/backend/domain/model/member/Participant.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/model/member/Participant.kt
@@ -12,7 +12,7 @@ data class Participant(
     val gender: GenderType,
     val birthDate: LocalDate,
     val basicAddressInfo: AddressInfo,
-    val additionalAddressInfo: AddressInfo?,
+    val additionalAddressInfo: AddressInfo,
     val matchType: MatchType?
 ) {
 
@@ -27,7 +27,7 @@ data class Participant(
             gender: GenderType,
             birthDate: LocalDate,
             basicAddressInfo: AddressInfo,
-            additionalAddressInfo: AddressInfo?,
+            additionalAddressInfo: AddressInfo,
             matchType: MatchType?
         ) = Participant(
             id = 0,

--- a/src/main/kotlin/com/dobby/backend/infrastructure/converter/ParticipantConverter.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/converter/ParticipantConverter.kt
@@ -24,7 +24,7 @@ object ParticipantConverter {
             gender = entity.gender,
             birthDate = entity.birthDate,
             basicAddressInfo = entity.basicAddressInfo.toModel(),
-            additionalAddressInfo = entity.additionalAddressInfo?.toModel(),
+            additionalAddressInfo = entity.additionalAddressInfo.toModel(),
             matchType = entity.matchType
         )
     }
@@ -47,7 +47,7 @@ object ParticipantConverter {
             birthDate = participant.birthDate,
             matchType = participant.matchType,
             basicAddressInfo = participant.basicAddressInfo.toEntity(),
-            additionalAddressInfo = participant.additionalAddressInfo?.toEntity()
+            additionalAddressInfo = participant.additionalAddressInfo.toEntity()
         )
     }
 

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/enums/areaInfo/Area.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/enums/areaInfo/Area.kt
@@ -1,9 +1,6 @@
 package com.dobby.backend.infrastructure.database.entity.enums.areaInfo
 
 enum class Area (val region: Region, val displayName: String){
-    // 기본값
-    NONE(Region.NONE, "NONE"),
-
     // 서울
     SEOUL_ALL(Region.SEOUL, "SEOUL_ALL"),
     GEUMCHEONGU(Region.SEOUL, "GEUMCHEONGU"),
@@ -298,7 +295,10 @@ enum class Area (val region: Region, val displayName: String){
 
     // 제주특별자치도
     JEJU_SEOGWIPOSI(Region.JEJU, "JEJU_SEOGWIPOSI"),
-    JEJU_JEJUSI(Region.JEJU, "JEJU_JEJUSI");
+    JEJU_JEJUSI(Region.JEJU, "JEJU_JEJUSI"),
+
+    // 기본값
+    NONE(Region.NONE, "NONE"),;
 
     companion object {
         fun findByRegion(region : Region) : List<Area> {

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/enums/areaInfo/Area.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/enums/areaInfo/Area.kt
@@ -1,6 +1,9 @@
 package com.dobby.backend.infrastructure.database.entity.enums.areaInfo
 
 enum class Area (val region: Region, val displayName: String){
+    // 기본값
+    NONE(Region.NONE, "NONE"),
+
     // 서울
     SEOUL_ALL(Region.SEOUL, "SEOUL_ALL"),
     GEUMCHEONGU(Region.SEOUL, "GEUMCHEONGU"),

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/enums/areaInfo/Region.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/enums/areaInfo/Region.kt
@@ -3,7 +3,6 @@ package com.dobby.backend.infrastructure.database.entity.enums.areaInfo
 import java.security.InvalidParameterException
 
 enum class Region(val displayName: String) {
-    NONE("NONE"),
     SEOUL("SEOUL"),
     GYEONGGI("GYEONGGI"),
     INCHEON("INCHEON"),
@@ -20,7 +19,8 @@ enum class Region(val displayName: String) {
     GWANGJU("GWANGJU"),
     JEONNAM("JEONNAM"),
     JEONBUK("JEONBUK"),
-    JEJU("JEJU");
+    JEJU("JEJU"),
+    NONE("NONE"),;
 
     fun getAreas(): List<Area> {
         return Area.findByRegion(this)

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/enums/areaInfo/Region.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/enums/areaInfo/Region.kt
@@ -3,6 +3,7 @@ package com.dobby.backend.infrastructure.database.entity.enums.areaInfo
 import java.security.InvalidParameterException
 
 enum class Region(val displayName: String) {
+    NONE("NONE"),
     SEOUL("SEOUL"),
     GYEONGGI("GYEONGGI"),
     INCHEON("INCHEON"),

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/member/ParticipantEntity.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/member/ParticipantEntity.kt
@@ -36,10 +36,10 @@ class ParticipantEntity (
 
     @Embedded
     @AttributeOverrides(
-        AttributeOverride(name = "region", column = Column(name = "optional_region", nullable = true)),
-        AttributeOverride(name = "area", column = Column(name = "optional_area", nullable = true))
+        AttributeOverride(name = "region", column = Column(name = "optional_region", nullable = false)),
+        AttributeOverride(name = "area", column = Column(name = "optional_area", nullable = false))
     )
-    val additionalAddressInfo: AddressInfo?,
+    val additionalAddressInfo: AddressInfo,
 
     @Column(name = "match_type", nullable = true)
     @Enumerated(EnumType.STRING)
@@ -52,7 +52,7 @@ class ParticipantEntity (
         gender = gender,
         birthDate = birthDate,
         basicAddressInfo = basicAddressInfo.toDomain(),
-        additionalAddressInfo = additionalAddressInfo?.toDomain(),
+        additionalAddressInfo = additionalAddressInfo.toDomain(),
         matchType = matchType
     )
 
@@ -63,8 +63,8 @@ class ParticipantEntity (
                 member = MemberEntity.fromDomain(member),
                 gender = gender,
                 birthDate = birthDate,
-                basicAddressInfo = AddressInfo.fromDomain(basicAddressInfo), // 수정: AddressInfo.fromDomain() 사용
-                additionalAddressInfo = additionalAddressInfo?.let { AddressInfo.fromDomain(it) }, // 수정
+                basicAddressInfo = AddressInfo.fromDomain(basicAddressInfo),
+                additionalAddressInfo = AddressInfo.fromDomain(additionalAddressInfo),
                 matchType = matchType
             )
         }

--- a/src/main/kotlin/com/dobby/backend/presentation/api/mapper/ExperimentPostMapper.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/mapper/ExperimentPostMapper.kt
@@ -210,8 +210,6 @@ object ExperimentPostMapper {
         )
     }
 
-
-
     fun toGeneratePreSignedUrlUseCaseInput(request: PreSignedUrlRequest): GenerateExperimentPostPreSignedUrlUseCase.Input {
         return GenerateExperimentPostPreSignedUrlUseCase.Input(
             fileName = request.fileName

--- a/src/main/kotlin/com/dobby/backend/presentation/api/mapper/MemberMapper.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/mapper/MemberMapper.kt
@@ -4,6 +4,8 @@ import com.dobby.backend.application.usecase.member.GetResearcherInfoUseCase
 import com.dobby.backend.application.usecase.member.CreateResearcherUseCase
 import com.dobby.backend.application.usecase.member.CreateParticipantUseCase
 import com.dobby.backend.application.usecase.member.GetParticipantInfoUseCase
+import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Area
+import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region
 import com.dobby.backend.presentation.api.dto.request.signup.ParticipantSignupRequest
 import com.dobby.backend.presentation.api.dto.request.signup.ResearcherSignupRequest
 import com.dobby.backend.presentation.api.dto.response.member.*
@@ -44,9 +46,10 @@ object MemberMapper {
                 region = req.basicAddressInfo.region,
                 area = req.basicAddressInfo.area
             ),
-            additionalAddressInfo = req.additionalAddressInfo?.let {
-                CreateParticipantUseCase.AddressInfo(region = it.region, area = it.area)
-            },
+            additionalAddressInfo = CreateParticipantUseCase.AddressInfo(
+                region = req.additionalAddressInfo?.region ?: Region.NONE,
+                area = req.additionalAddressInfo?.area ?: Area.NONE
+            ),
             matchType = req.matchType
         )
     }


### PR DESCRIPTION
## 💡 작업 내용
- 추가 지역에 대해 선택하지 않은 참여자 지역 정보에 NONE 값 적용

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- 해당 부분은 디스코드에서 미리 논의한 거라 추가 설명은 생략하겠습니다
- 참여자 관련 API를 테스트 해보며 잘 동작하는지 확인했지만 추가적으로 수정해야 할 부분이 있는지 확인해주세요