### PR TITLE
[YS-160] refact: 연구자 회원가입 요청에서 사용하지 않는 이메일 인증 필드 삭제

### DIFF
--- a/src/main/kotlin/com/dobby/backend/application/mapper/VerificationMapper.kt
+++ b/src/main/kotlin/com/dobby/backend/application/mapper/VerificationMapper.kt
@@ -4,7 +4,7 @@ import com.dobby.backend.application.usecase.member.email.EmailCodeSendUseCase
 import com.dobby.backend.application.usecase.member.email.EmailVerificationUseCase
 import com.dobby.backend.infrastructure.database.entity.VerificationEntity
 import com.dobby.backend.infrastructure.database.entity.enums.VerificationStatus
-import com.dobby.backend.presentation.api.dto.request.signup.EmailSendRequest
+import com.dobby.backend.presentation.api.dto.request.member.EmailSendRequest
 
 object VerificationMapper {
     fun toEntity(req: EmailSendRequest, code : String): VerificationEntity {

--- a/src/main/kotlin/com/dobby/backend/application/usecase/member/CreateResearcherUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/member/CreateResearcherUseCase.kt
@@ -20,7 +20,6 @@ class CreateResearcherUseCase(
         val provider: ProviderType,
         val contactEmail: String,
         val univEmail : String,
-        val emailVerified: Boolean,
         val univName: String,
         val name : String,
         val major: String,
@@ -74,7 +73,7 @@ class CreateResearcherUseCase(
             member = member,
             univEmail = input.univEmail,
             univName = input.univName,
-            emailVerified = input.emailVerified,
+            emailVerified = true,
             major = input.major,
             labInfo = input.labInfo
         )

--- a/src/main/kotlin/com/dobby/backend/presentation/api/controller/EmailController.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/controller/EmailController.kt
@@ -1,8 +1,8 @@
 package com.dobby.backend.presentation.api.controller
 
 import com.dobby.backend.application.service.EmailService
-import com.dobby.backend.presentation.api.dto.request.signup.EmailSendRequest
-import com.dobby.backend.presentation.api.dto.request.signup.EmailVerificationRequest
+import com.dobby.backend.presentation.api.dto.request.member.EmailSendRequest
+import com.dobby.backend.presentation.api.dto.request.member.EmailVerificationRequest
 import com.dobby.backend.presentation.api.dto.response.member.EmailSendResponse
 import com.dobby.backend.presentation.api.dto.response.member.EmailVerificationResponse
 import com.dobby.backend.presentation.api.mapper.EmailMapper

--- a/src/main/kotlin/com/dobby/backend/presentation/api/controller/MemberController.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/controller/MemberController.kt
@@ -1,8 +1,8 @@
 package com.dobby.backend.presentation.api.controller
 
 import com.dobby.backend.application.service.MemberService
-import com.dobby.backend.presentation.api.dto.request.signup.ParticipantSignupRequest
-import com.dobby.backend.presentation.api.dto.request.signup.ResearcherSignupRequest
+import com.dobby.backend.presentation.api.dto.request.member.ParticipantSignupRequest
+import com.dobby.backend.presentation.api.dto.request.member.ResearcherSignupRequest
 import com.dobby.backend.presentation.api.dto.response.member.ParticipantInfoResponse
 import com.dobby.backend.presentation.api.dto.response.member.ResearcherInfoResponse
 import com.dobby.backend.presentation.api.dto.response.member.SignupResponse

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/member/EmailSendRequest.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/member/EmailSendRequest.kt
@@ -1,16 +1,12 @@
-package com.dobby.backend.presentation.api.dto.request.signup
+package com.dobby.backend.presentation.api.dto.request.member
 
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotNull
 
-data class EmailVerificationRequest (
+data class EmailSendRequest (
     @Email(message = "학교 이메일이 유효하지 않습니다.")
     @NotNull(message = "학교 이메일은 공백일 수 없습니다.")
     @Schema(description = "대학교 이메일")
     val univEmail : String,
-
-    @NotNull(message = "인증 코드는 공백일 수 없습니다.")
-    @Schema(description = "인증 코드")
-    val inputCode: String,
 )

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/member/EmailVerificationRequest.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/member/EmailVerificationRequest.kt
@@ -1,12 +1,16 @@
-package com.dobby.backend.presentation.api.dto.request.signup
+package com.dobby.backend.presentation.api.dto.request.member
 
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotNull
 
-data class EmailSendRequest (
+data class EmailVerificationRequest (
     @Email(message = "학교 이메일이 유효하지 않습니다.")
     @NotNull(message = "학교 이메일은 공백일 수 없습니다.")
     @Schema(description = "대학교 이메일")
     val univEmail : String,
+
+    @NotNull(message = "인증 코드는 공백일 수 없습니다.")
+    @Schema(description = "인증 코드")
+    val inputCode: String,
 )

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/member/ParticipantSignupRequest.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/member/ParticipantSignupRequest.kt
@@ -1,4 +1,4 @@
-package com.dobby.backend.presentation.api.dto.request.signup
+package com.dobby.backend.presentation.api.dto.request.member
 
 import com.dobby.backend.infrastructure.database.entity.enums.GenderType
 import com.dobby.backend.infrastructure.database.entity.enums.MatchType

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/member/ResearcherSignupRequest.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/member/ResearcherSignupRequest.kt
@@ -1,10 +1,9 @@
-package com.dobby.backend.presentation.api.dto.request.signup
+package com.dobby.backend.presentation.api.dto.request.member
 
 import com.dobby.backend.infrastructure.database.entity.enums.ProviderType
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
-import jakarta.validation.constraints.NotNull
 
 data class ResearcherSignupRequest(
     @Email(message = "OAuth 이메일이 유효하지 않습니다.")
@@ -25,10 +24,6 @@ data class ResearcherSignupRequest(
     @NotBlank(message = "학교 이메일은 공백일 수 없습니다.")
     @Schema(description = "대학교 이메일")
     val univEmail : String,
-
-    @NotNull(message = "이메일 인증 여부는 공백일 수 없습니다.")
-    @Schema(description = "이메일 인증 여부")
-    var emailVerified: Boolean,
 
     @NotBlank(message = "이름은 공백일 수 없습니다.")
     @Schema(description = "이름")

--- a/src/main/kotlin/com/dobby/backend/presentation/api/mapper/EmailMapper.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/mapper/EmailMapper.kt
@@ -2,8 +2,8 @@ package com.dobby.backend.presentation.api.mapper
 
 import com.dobby.backend.application.usecase.member.email.EmailCodeSendUseCase
 import com.dobby.backend.application.usecase.member.email.EmailVerificationUseCase
-import com.dobby.backend.presentation.api.dto.request.signup.EmailSendRequest
-import com.dobby.backend.presentation.api.dto.request.signup.EmailVerificationRequest
+import com.dobby.backend.presentation.api.dto.request.member.EmailSendRequest
+import com.dobby.backend.presentation.api.dto.request.member.EmailVerificationRequest
 import com.dobby.backend.presentation.api.dto.response.member.EmailSendResponse
 import com.dobby.backend.presentation.api.dto.response.member.EmailVerificationResponse
 

--- a/src/main/kotlin/com/dobby/backend/presentation/api/mapper/MemberMapper.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/mapper/MemberMapper.kt
@@ -6,8 +6,8 @@ import com.dobby.backend.application.usecase.member.CreateParticipantUseCase
 import com.dobby.backend.application.usecase.member.GetParticipantInfoUseCase
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Area
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region
-import com.dobby.backend.presentation.api.dto.request.signup.ParticipantSignupRequest
-import com.dobby.backend.presentation.api.dto.request.signup.ResearcherSignupRequest
+import com.dobby.backend.presentation.api.dto.request.member.ParticipantSignupRequest
+import com.dobby.backend.presentation.api.dto.request.member.ResearcherSignupRequest
 import com.dobby.backend.presentation.api.dto.response.member.*
 import com.dobby.backend.util.getCurrentMemberId
 
@@ -18,7 +18,6 @@ object MemberMapper {
             provider = req.provider,
             contactEmail = req.contactEmail,
             univEmail = req.univEmail,
-            emailVerified = req.emailVerified,
             univName = req.univName,
             name = req.name,
             major = req.major,


### PR DESCRIPTION
## 💡 작업 내용
- 연구자 회원가입 요청에서 사용하지 않는 이메일 인증 필드 삭제

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- 이미 논의된 사항이라 바로 머지합니다


## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-160