### PR TITLE
[YS-161] 공고 전체 목록 조회 모집 상태 오타 수정

### DIFF
--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/experiment/ExperimentPostsResponse.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/experiment/ExperimentPostsResponse.kt
@@ -1,5 +1,5 @@
 package com.dobby.backend.presentation.api.dto.response.experiment
 data class ExperimentPostsResponse (
     val postInfo: PostInfo,
-    val recuritDone: Boolean
+    val recruitDone: Boolean
 )

--- a/src/main/kotlin/com/dobby/backend/presentation/api/mapper/ExperimentPostMapper.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/mapper/ExperimentPostMapper.kt
@@ -206,7 +206,7 @@ object ExperimentPostMapper {
                     endDate = output.postInfo.durationInfo.endDate
                 )
             ),
-            recuritDone = output.postInfo.recruitDone
+            recruitDone = output.postInfo.recruitDone
         )
     }
 


### PR DESCRIPTION
## 💡 작업 내용
- 공고 전체 목록 조회 모집 상태 필드값인 `recuritDone` 의 오타를 발견하여, `recruitDone` 으로 수정하였습니다.

![image](https://github.com/user-attachments/assets/31ffb07a-8b62-4036-b9ef-839d42271eed)


## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- 관련된 Discussion 등이 있다면 첨부해주세요
사소한 오타 수정이며, 리뷰가 필요 없다고 판단하여 **예외적으로 리뷰없이 merge**하겠습니다.

## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-161