### PR TITLE
[YS-170] refact: 실험 공고 상세 정보 조회 응답에 `isAuthor` 추가 및 JwtOptionalAuthenticationFilter 추가

### DIFF
--- a/src/main/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostDetailUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostDetailUseCase.kt
@@ -12,7 +12,8 @@ class GetExperimentPostDetailUseCase(
 ) : UseCase<GetExperimentPostDetailUseCase.Input, GetExperimentPostDetailUseCase.Output> {
 
     data class Input(
-        val experimentPostId: Long
+        val experimentPostId: Long,
+        val memberId: Long?
     )
 
     data class Output(
@@ -26,12 +27,12 @@ class GetExperimentPostDetailUseCase(
         experimentPostGateway.save(experimentPost)
 
         return Output(
-            experimentPostDetailResponse = experimentPost.toDetailResponse()
+            experimentPostDetailResponse = experimentPost.toDetailResponse(input.memberId)
         )
     }
 }
 
-fun ExperimentPost.toDetailResponse(): ExperimentPostDetailResponse {
+fun ExperimentPost.toDetailResponse(memberId: Long?): ExperimentPostDetailResponse {
     return ExperimentPostDetailResponse(
         experimentPostId = this.id,
         title = this.title,
@@ -43,7 +44,8 @@ fun ExperimentPost.toDetailResponse(): ExperimentPostDetailResponse {
         targetGroup = this.targetGroup.toResponse(),
         address = this.toAddressResponse(),
         content = this.content,
-        imageList = this.images.map { it.imageUrl }
+        imageList = this.images.map { it.imageUrl },
+        isAuthor = this.member.id == memberId
     )
 }
 

--- a/src/main/kotlin/com/dobby/backend/presentation/api/config/filter/JwtOptionalAuthenticationFilter.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/config/filter/JwtOptionalAuthenticationFilter.kt
@@ -1,0 +1,39 @@
+package com.dobby.backend.presentation.api.config.filter
+
+import com.dobby.backend.domain.exception.AuthenticationTokenNotValidException
+import com.dobby.backend.infrastructure.token.JwtTokenProvider
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.filter.OncePerRequestFilter
+import org.springframework.web.servlet.HandlerExceptionResolver
+
+class JwtOptionalAuthenticationFilter(
+    private val jwtTokenProvider: JwtTokenProvider,
+    private val handlerExceptionResolver: HandlerExceptionResolver,
+) : OncePerRequestFilter() {
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        try {
+            val authenticationHeader = request.getHeader("Authorization")
+
+            if (authenticationHeader != null && authenticationHeader.startsWith("Bearer ")) {
+                val accessToken = if (authenticationHeader.startsWith("Bearer "))
+                    authenticationHeader.substring(7)
+                else throw AuthenticationTokenNotValidException()
+
+                val authentication = jwtTokenProvider.parseAuthentication(accessToken)
+                SecurityContextHolder.getContext().authentication = authentication
+            }
+
+            // 헤더가 없으면 인증 없이 진행
+            filterChain.doFilter(request, response)
+        } catch (e: Exception) {
+            handlerExceptionResolver.resolveException(request, response, null, e)
+        }
+    }
+}

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/experiment/ExperimentPostDetailResponse.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/experiment/ExperimentPostDetailResponse.kt
@@ -41,7 +41,10 @@ data class ExperimentPostDetailResponse(
     val content: String,
 
     @Schema(description = "이미지 목록", example = "[\"https://bucket/image1.webp\", \"https://bucket/image2.webp\"]")
-    val imageList: List<String>
+    val imageList: List<String>,
+
+    @Schema(description = "글쓴이 여부", example = "true")
+    val isAuthor: Boolean
 ) {
     @Schema(description = "실험 공고 요약 정보")
     data class SummaryResponse(

--- a/src/main/kotlin/com/dobby/backend/presentation/api/mapper/ExperimentPostMapper.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/mapper/ExperimentPostMapper.kt
@@ -13,6 +13,7 @@ import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region
 import com.dobby.backend.presentation.api.dto.request.experiment.*
 import com.dobby.backend.presentation.api.dto.response.experiment.*
 import com.dobby.backend.util.getCurrentMemberId
+import com.dobby.backend.util.getCurrentMemberIdOrNull
 
 object ExperimentPostMapper {
     fun toCreatePostUseCaseInput(request: CreateExperimentPostRequest): CreateExperimentPostUseCase.Input {
@@ -85,7 +86,8 @@ object ExperimentPostMapper {
 
     fun toGetExperimentPostDetailUseCaseInput(experimentPostId: Long): GetExperimentPostDetailUseCase.Input {
         return GetExperimentPostDetailUseCase.Input(
-            experimentPostId = experimentPostId
+            experimentPostId = experimentPostId,
+            memberId = getCurrentMemberIdOrNull()
         )
     }
 
@@ -101,7 +103,8 @@ object ExperimentPostMapper {
             targetGroup = response.experimentPostDetailResponse.targetGroup,
             address = response.experimentPostDetailResponse.address,
             content = response.experimentPostDetailResponse.content,
-            imageList = response.experimentPostDetailResponse.imageList
+            imageList = response.experimentPostDetailResponse.imageList,
+            isAuthor = response.experimentPostDetailResponse.isAuthor
         )
     }
 

--- a/src/main/kotlin/com/dobby/backend/util/AuthenticationUtils.kt
+++ b/src/main/kotlin/com/dobby/backend/util/AuthenticationUtils.kt
@@ -5,12 +5,5 @@ import org.springframework.security.core.context.SecurityContextHolder
 fun getCurrentMemberId() = SecurityContextHolder.getContext().authentication.name.toLong()
 
 fun getCurrentMemberIdOrNull(): Long? {
-    val authentication = SecurityContextHolder.getContext().authentication
-    val name = authentication?.name
-
-    return if (name != null && name != "anonymousUser") {
-        name.toLong()
-    } else {
-        null
-    }
+    return SecurityContextHolder.getContext().authentication?.name?.takeIf { it != "anonymousUser" }?.toLong()
 }

--- a/src/main/kotlin/com/dobby/backend/util/AuthenticationUtils.kt
+++ b/src/main/kotlin/com/dobby/backend/util/AuthenticationUtils.kt
@@ -3,3 +3,14 @@ package com.dobby.backend.util
 import org.springframework.security.core.context.SecurityContextHolder
 
 fun getCurrentMemberId() = SecurityContextHolder.getContext().authentication.name.toLong()
+
+fun getCurrentMemberIdOrNull(): Long? {
+    val authentication = SecurityContextHolder.getContext().authentication
+    val name = authentication?.name
+
+    return if (name != null && name != "anonymousUser") {
+        name.toLong()
+    } else {
+        null
+    }
+}


### PR DESCRIPTION
## 💡 작업 내용
- 프론트의 요청으로 실험 공고 상세 정보 조회 응답에 `isAuthor` 추가
- JwtOptionalAuthenticationFilter 추가
  - 해당 부분에 대해서는 코멘트로 설명하겠습니다 

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- Security 관련 로직에서 변경사항이 생겨 `인증이 필요한 API / 인증이 필요하지 않은 API / 인증은 필요없지만 회원인 경우 memberId를 확인해야 하는 API` 에 대해 로컬에서 API 테스트를 진행했습니다. 제가 놓친 부분이 있다면 알려주세요~


## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-170

## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-170