### PR TITLE
[YS-174] refact: 코드 커버리지 측정을 위해 추가했던 Jacoco 및 Sonarcloud 설정 제거

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -11,8 +11,7 @@ on:
       - dev
 
 jobs:
-  test:
-    name: Code Quality Check
+  build:
     runs-on: ubuntu-latest
 
     steps:
@@ -27,21 +26,5 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Cache SonarCloud packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
-
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: check
-          cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' }}
-
-      - name: Build and analyze
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew build sonar --info
+      - name: Build with Gradle
+        run: ./gradlew clean build

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,8 +5,6 @@ plugins {
 	kotlin("kapt") version "1.9.25"
 	id("org.springframework.boot") version "3.4.1"
 	id("io.spring.dependency-management") version "1.1.7"
-	id("jacoco")
-	id("org.sonarqube") version "6.0.1.5171"
 }
 
 group = "com.dobby"
@@ -126,103 +124,6 @@ kapt {
 	generateStubs = true
 }
 
-
-jacoco {
-	toolVersion = "0.8.8"
-}
-
 tasks.withType<Test> {
 	useJUnitPlatform()
-	finalizedBy(tasks.jacocoTestReport)
-}
-
-sonar {
-	properties {
-		property("sonar.projectKey", "YAPP-Github_25th-Web-Team-2-BE")
-		property("sonar.organization", "yapp-github")
-		property("sonar.host.url", "https://sonarcloud.io")
-		property("sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/index.xml")
-		property("sonar.sources", "src/main/kotlin")
-		property("sonar.sourceEncoding", "UTF-8")
-		property("sonar.exclusions", "**/test/**, **/resources/**, **/*Application*.kt, **/*Controller*.kt, " +
-				"**/*Config.kt, **/*Entity*.kt, **/*Repository*.kt, **/*Dto*.kt, **/*Response*.kt, **/*Request*.kt, **/*Exception*.kt," +
-				"**/config/**, **/domain/gateway/**, **/domain/model/**, **/infrastructure/**, **/presentation/**, **/util/**")
-		property("sonar.test.inclusions", "**/*Test.kt")
-		property("sonar.kotlin.coveragePlugin", "jacoco")
-	}
-}
-
-tasks.jacocoTestReport {
-	dependsOn(tasks.test)
-	reports{
-		html.required.set(true)
-		xml.required.set(true)
-		html.outputLocation.set(file(layout.buildDirectory.dir("reports/jacoco/index.html").get().asFile))
-		xml.outputLocation.set(file(layout.buildDirectory.dir("reports/jacoco/index.xml").get().asFile))
-	}
-
-	val Qdomains = mutableListOf<String>()  // 초기화
-	for (qPattern in listOf("**/QA", "**/QZ")) {
-		Qdomains.add("$qPattern*")
-	}
-
-	classDirectories.setFrom(
-		files(
-			classDirectories.files.flatMap { dir ->
-				fileTree(dir) {
-					exclude(
-						"**/*Application*",
-						"**/config/*",
-						"**/domain/exception/*",
-						"**/domain/gateway/*",
-						"**/domain/model/*",
-						"**/infrastructure/*",
-						"**/presentation/*",
-						"**/util/*",
-						*Qdomains.toTypedArray()
-					)
-				}.files
-			}
-		)
-	)
-	finalizedBy(tasks.jacocoTestCoverageVerification)
-}
-
-tasks.jacocoTestCoverageVerification {
-	val Qdomains = mutableListOf<String>()
-	for (qPattern in listOf("**/QA", "**/QZ")) {
-		Qdomains.add("$qPattern*")
-	}
-
-	violationRules {
-		rule {
-			isFailOnViolation = false
-			isEnabled = true
-			element = "CLASS"
-
-			limit {
-				counter = "LINE"
-				value = "COVEREDRATIO"
-				minimum = 0.70.toBigDecimal()
-			}
-
-			limit {
-				counter = "BRANCH"
-				value = "COVEREDRATIO"
-				minimum = 0.70.toBigDecimal()
-			}
-
-			excludes = listOf(
-				"**.*Application*",
-				"**.config.*",
-				"**.domain.exception.*",
-				"**.domain.gateway.*",
-				"**.domain.model.*",
-				"**.infrastructure.*",
-				"**.presentation.*",
-				"**.util.*",
-				*Qdomains.toTypedArray()
-			)
-		}
-	}
 }


### PR DESCRIPTION
## 💡 작업 내용
- 작업한 내용을 간략하게 리스트로 적어주세요

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- 소나클라우드의 높은 패스 기준으로 인해 팀 협의 후 설정을 제거하였습니다 🥲
- **소나클라우드에서 해당 레포지토리 권한이 제거됨을 확인한 후, 머지하겠습니다**


## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-174