### PR TITLE
[YS-177] refact: 실험 공고 전체 조회 API 응답에 페이지네이션 관련 필드 포함하도록 리팩터링

### DIFF
--- a/src/main/kotlin/com/dobby/backend/application/mapper/ExperimentMapper.kt
+++ b/src/main/kotlin/com/dobby/backend/application/mapper/ExperimentMapper.kt
@@ -1,5 +1,6 @@
 package com.dobby.backend.application.mapper
 
+import com.dobby.backend.application.usecase.experiment.GetExperimentPostTotalCountByCustomFilterUseCase
 import com.dobby.backend.application.usecase.experiment.GetExperimentPostsUseCase
 import com.dobby.backend.domain.model.experiment.CustomFilter
 import com.dobby.backend.domain.model.experiment.LocationTarget
@@ -8,6 +9,25 @@ import com.dobby.backend.domain.model.experiment.StudyTarget
 
 object ExperimentMapper {
     fun toDomainFilter(customFilter: GetExperimentPostsUseCase.CustomFilterInput): CustomFilter {
+        return CustomFilter(
+            matchType = customFilter.matchType,
+            studyTarget = customFilter.studyTarget?.let {
+                StudyTarget(
+                    gender = it.gender,
+                    age = it.age
+                )
+            },
+            locationTarget = customFilter.locationTarget?.let {
+                LocationTarget(
+                    region = it.region,
+                    areas = it.areas
+                )
+            },
+            recruitStatus = customFilter.recruitStatus
+        )
+    }
+
+    fun toDomainFilter(customFilter: GetExperimentPostTotalCountByCustomFilterUseCase.Input): CustomFilter {
         return CustomFilter(
             matchType = customFilter.matchType,
             studyTarget = customFilter.studyTarget?.let {

--- a/src/main/kotlin/com/dobby/backend/application/service/ExperimentPostService.kt
+++ b/src/main/kotlin/com/dobby/backend/application/service/ExperimentPostService.kt
@@ -10,7 +10,6 @@ import com.dobby.backend.domain.exception.ExperimentAreaOverflowException
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Area
 import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
-import java.time.LocalDate
 
 @Service
 class ExperimentPostService(
@@ -21,7 +20,8 @@ class ExperimentPostService(
     private val getExperimentPostCountsByAreaUseCase: GetExperimentPostCountsByAreaUseCase,
     private val getExperimentPostApplyMethodUseCase: GetExperimentPostApplyMethodUseCase,
     private val generateExperimentPostPreSignedUrlUseCase: GenerateExperimentPostPreSignedUrlUseCase,
-    private val updateExpiredExperimentPostUseCase: UpdateExpiredExperimentPostUseCase
+    private val updateExpiredExperimentPostUseCase: UpdateExpiredExperimentPostUseCase,
+    private val getExperimentPostTotalCountByCustomFilterUseCase: GetExperimentPostTotalCountByCustomFilterUseCase
 ) {
     @Transactional
     fun createNewExperimentPost(input: CreateExperimentPostUseCase.Input): CreateExperimentPostUseCase.Output {
@@ -78,5 +78,9 @@ class ExperimentPostService(
     }
     fun generatePreSignedUrl(input: GenerateExperimentPostPreSignedUrlUseCase.Input): GenerateExperimentPostPreSignedUrlUseCase.Output {
         return generateExperimentPostPreSignedUrlUseCase.execute(input)
+    }
+
+    fun getTotalExperimentPostCount(input: GetExperimentPostTotalCountByCustomFilterUseCase.Input): Int {
+        return getExperimentPostTotalCountByCustomFilterUseCase.execute(input)
     }
 }

--- a/src/main/kotlin/com/dobby/backend/application/service/ExperimentPostService.kt
+++ b/src/main/kotlin/com/dobby/backend/application/service/ExperimentPostService.kt
@@ -80,7 +80,7 @@ class ExperimentPostService(
         return generateExperimentPostPreSignedUrlUseCase.execute(input)
     }
 
-    fun getTotalExperimentPostCount(input: GetExperimentPostTotalCountByCustomFilterUseCase.Input): Int {
+    fun getExperimentPostTotalCount(input: GetExperimentPostTotalCountByCustomFilterUseCase.Input): Int {
         return getExperimentPostTotalCountByCustomFilterUseCase.execute(input)
     }
 }

--- a/src/main/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostTotalCountByCustomFilterUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostTotalCountByCustomFilterUseCase.kt
@@ -1,0 +1,25 @@
+package com.dobby.backend.application.usecase.experiment
+
+import com.dobby.backend.application.mapper.ExperimentMapper
+import com.dobby.backend.application.usecase.UseCase
+import com.dobby.backend.domain.gateway.experiment.ExperimentPostGateway
+import com.dobby.backend.infrastructure.database.entity.enums.MatchType
+import com.dobby.backend.infrastructure.database.entity.enums.experiment.RecruitStatus
+
+class GetExperimentPostTotalCountByCustomFilterUseCase(
+    private val experimentPostGateway: ExperimentPostGateway
+) : UseCase<GetExperimentPostTotalCountByCustomFilterUseCase.Input, Int> {
+
+    data class Input(
+        val matchType: MatchType?,
+        val studyTarget: GetExperimentPostsUseCase.StudyTargetInput?,
+        val locationTarget: GetExperimentPostsUseCase.LocationTargetInput?,
+        val recruitStatus: RecruitStatus
+    )
+
+    override fun execute(input: Input): Int {
+        return experimentPostGateway.countExperimentPostsByCustomFilter(
+            ExperimentMapper.toDomainFilter(input)
+        )
+    }
+}

--- a/src/main/kotlin/com/dobby/backend/domain/gateway/experiment/ExperimentPostGateway.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/gateway/experiment/ExperimentPostGateway.kt
@@ -22,4 +22,5 @@ interface ExperimentPostGateway {
     fun updateExperimentPostStatus(currentDate : LocalDate) : Long
     fun findExperimentPostsByMemberIdWithPagination(memberId: Long, pagination: Pagination, order: String): List<ExperimentPost>?
     fun countExperimentPostsByMemberId(memberId: Long): Int
+    fun countExperimentPostsByCustomFilter(customFilter: CustomFilter): Int
 }

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/repository/ExperimentPostCustomRepository.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/repository/ExperimentPostCustomRepository.kt
@@ -14,9 +14,12 @@ interface ExperimentPostCustomRepository {
     ): List<ExperimentPostEntity>?
 
     fun updateExperimentPostStatus(currentDate : LocalDate): Long
+
     fun findExperimentPostsByMemberIdWithPagination(
         memberId: Long,
         pagination: Pagination,
         order: String
     ): List<ExperimentPostEntity>?
+
+    fun countExperimentPostsByCustomFilter(customFilter: CustomFilter): Int
 }

--- a/src/main/kotlin/com/dobby/backend/infrastructure/gateway/experiment/ExperimentPostGatewayImpl.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/gateway/experiment/ExperimentPostGatewayImpl.kt
@@ -92,4 +92,8 @@ class ExperimentPostGatewayImpl(
     override fun countExperimentPostsByMemberId(memberId: Long): Int {
         return experimentPostRepository.countByMemberId(memberId)
     }
+
+    override fun countExperimentPostsByCustomFilter(customFilter: CustomFilter): Int {
+        return experimentPostCustomRepository.countExperimentPostsByCustomFilter(customFilter)
+    }
 }

--- a/src/main/kotlin/com/dobby/backend/presentation/api/controller/ExperimentPostController.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/controller/ExperimentPostController.kt
@@ -118,8 +118,8 @@ class ExperimentPostController (
         val input = ExperimentPostMapper.toGetExperimentPostsUseCaseInput(customFilter, pagination)
         val posts = experimentPostService.getExperimentPosts(input)
 
-        val totalCountInput = ExperimentPostMapper.toGetTotalExperimentPostCountUseCaseInput(customFilter)
-        val totalCount = experimentPostService.getTotalExperimentPostCount(totalCountInput)
+        val totalCountInput = ExperimentPostMapper.toGetExperimentPostTotalCountUseCaseInput(customFilter)
+        val totalCount = experimentPostService.getExperimentPostTotalCount(totalCountInput)
         val isLast = paginationService.isLastPage(totalCount, page, count)
         return ExperimentPostMapper.toGetExperimentPostsResponse(posts, page, totalCount, isLast)
     }

--- a/src/main/kotlin/com/dobby/backend/presentation/api/controller/MemberController.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/controller/MemberController.kt
@@ -93,11 +93,7 @@ class MemberController(
 
         val totalCountInput = MemberMapper.toGetTotalMyExperimentPostCountUseCaseInput()
         val totalCount = memberService.getMyExperimentPostsCount(totalCountInput).totalPostCount
-        val isLast = paginationService.isLastPage(
-            totalElements = totalCount,
-            pageSize = count,
-            currentPage = page
-        )
+        val isLast = paginationService.isLastPage(totalCount, count, page)
         return MemberMapper.toGetMyExperimentPostsResponse(posts, page, totalCount, isLast)
     }
 }

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/experiment/ExperimentPostResponse.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/experiment/ExperimentPostResponse.kt
@@ -1,6 +1,6 @@
 package com.dobby.backend.presentation.api.dto.response.experiment
 
-data class ExperimentPostsResponse (
+data class ExperimentPostResponse (
     val postInfo: PostInfo,
     val recruitStatus: Boolean
 )

--- a/src/main/kotlin/com/dobby/backend/presentation/api/mapper/ExperimentPostMapper.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/mapper/ExperimentPostMapper.kt
@@ -12,6 +12,7 @@ import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Area
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region
 import com.dobby.backend.infrastructure.database.entity.enums.experiment.RecruitStatus
 import com.dobby.backend.presentation.api.dto.request.experiment.*
+import com.dobby.backend.presentation.api.dto.response.PaginatedResponse
 import com.dobby.backend.presentation.api.dto.response.experiment.*
 import com.dobby.backend.util.getCurrentMemberId
 import com.dobby.backend.util.getCurrentMemberIdOrNull
@@ -201,21 +202,33 @@ object ExperimentPostMapper {
         )
     }
 
-    fun toGetExperimentPostsResponse(output: GetExperimentPostsUseCase.Output): ExperimentPostsResponse {
-        return ExperimentPostsResponse(
-            postInfo = PostInfo(
-                experimentPostId = output.postInfo.experimentPostId,
-                title = output.postInfo.title,
-                views = output.postInfo.views,
-                univName = output.postInfo.univName,
-                reward = output.postInfo.reward,
-                durationInfo = DurationInfo(
-                    startDate = output.postInfo.durationInfo?.startDate,
-                    endDate = output.postInfo.durationInfo?.endDate
-
+    fun toGetExperimentPostsResponse(
+        output: List<GetExperimentPostsUseCase.Output>,
+        page: Int,
+        totalCount: Int,
+        isLast: Boolean
+    ): PaginatedResponse<ExperimentPostResponse> {
+        return PaginatedResponse(
+            content = output.map { post ->
+                ExperimentPostResponse(
+                    postInfo = PostInfo(
+                        experimentPostId = post.postInfo.experimentPostId,
+                        title = post.postInfo.title,
+                        views = post.postInfo.views,
+                        univName = post.postInfo.univName,
+                        reward = post.postInfo.reward,
+                        durationInfo = DurationInfo(
+                            startDate = post.postInfo.durationInfo.startDate,
+                            endDate = post.postInfo.durationInfo.endDate
+                        )
+                    ),
+                    recruitStatus = post.postInfo.recruitStatus
                 )
-            ),
-            recruitStatus = output.postInfo.recruitStatus
+            },
+            page = page,
+            size = output.size,
+            totalCount = totalCount,
+            isLast = isLast
         )
     }
 
@@ -228,6 +241,25 @@ object ExperimentPostMapper {
     fun toGeneratePreSignedUrlResponse(output: GenerateExperimentPostPreSignedUrlUseCase.Output): PreSignedUrlResponse {
         return PreSignedUrlResponse(
             preSignedUrl = output.preSignedUrl
+        )
+    }
+
+    fun toGetTotalExperimentPostCountUseCaseInput(customFilter: GetExperimentPostsUseCase.CustomFilterInput): GetExperimentPostTotalCountByCustomFilterUseCase.Input {
+        return GetExperimentPostTotalCountByCustomFilterUseCase.Input(
+            matchType = customFilter.matchType,
+            studyTarget = customFilter.studyTarget?.let {
+                GetExperimentPostsUseCase.StudyTargetInput(
+                    gender = it.gender,
+                    age = it.age
+                )
+            },
+            locationTarget = customFilter.locationTarget?.let {
+                GetExperimentPostsUseCase.LocationTargetInput(
+                    region = it.region,
+                    areas = it.areas
+                )
+            },
+            recruitStatus = customFilter.recruitStatus
         )
     }
 }

--- a/src/main/kotlin/com/dobby/backend/presentation/api/mapper/ExperimentPostMapper.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/mapper/ExperimentPostMapper.kt
@@ -244,7 +244,7 @@ object ExperimentPostMapper {
         )
     }
 
-    fun toGetTotalExperimentPostCountUseCaseInput(customFilter: GetExperimentPostsUseCase.CustomFilterInput): GetExperimentPostTotalCountByCustomFilterUseCase.Input {
+    fun toGetExperimentPostTotalCountUseCaseInput(customFilter: GetExperimentPostsUseCase.CustomFilterInput): GetExperimentPostTotalCountByCustomFilterUseCase.Input {
         return GetExperimentPostTotalCountByCustomFilterUseCase.Input(
             matchType = customFilter.matchType,
             studyTarget = customFilter.studyTarget?.let {

--- a/src/test/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostTotalCountByCustomFilterUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostTotalCountByCustomFilterUseCaseTest.kt
@@ -1,0 +1,56 @@
+package com.dobby.backend.application.usecase.experiment
+
+import com.dobby.backend.domain.gateway.experiment.ExperimentPostGateway
+import com.dobby.backend.infrastructure.database.entity.enums.MatchType
+import com.dobby.backend.infrastructure.database.entity.enums.experiment.RecruitStatus
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+
+class GetExperimentPostTotalCountByCustomFilterUseCaseTest : BehaviorSpec({
+    val experimentPostGateway = mockk<ExperimentPostGateway>()
+    val getExperimentPostTotalCountByCustomFilterUseCase = GetExperimentPostTotalCountByCustomFilterUseCase(experimentPostGateway)
+
+    given("유효한 필터 조건이 주어졌을 때") {
+        val input = GetExperimentPostTotalCountByCustomFilterUseCase.Input(
+            matchType = MatchType.ALL,
+            studyTarget = null,
+            locationTarget = null,
+            recruitStatus = RecruitStatus.ALL
+        )
+
+        every {
+            experimentPostGateway.countExperimentPostsByCustomFilter(any())
+        } returns 10
+
+        `when`("execute가 호출되면") {
+            val result = getExperimentPostTotalCountByCustomFilterUseCase.execute(input)
+
+            then("올바른 게시글 개수를 반환한다") {
+                result shouldBe 10
+            }
+        }
+    }
+
+    given("필터 조건에 맞는 게시글이 없을 때") {
+        val input = GetExperimentPostTotalCountByCustomFilterUseCase.Input(
+            matchType = MatchType.OFFLINE,
+            studyTarget = null,
+            locationTarget = null,
+            recruitStatus = RecruitStatus.OPEN
+        )
+
+        every {
+            experimentPostGateway.countExperimentPostsByCustomFilter(any())
+        } returns 0
+
+        `when`("execute가 호출되면") {
+            val result = getExperimentPostTotalCountByCustomFilterUseCase.execute(input)
+
+            then("게시글 개수가 0으로 반환된다") {
+                result shouldBe 0
+            }
+        }
+    }
+})


### PR DESCRIPTION
## 💡 작업 내용
- 실험 공고 전체 조회 API 응답에 페이지네이션 관련 필드 포함하도록 리팩터링

**마지막 페이지가 아닌 경우**
<img width="420" alt="스크린샷 2025-01-20 오전 10 03 50" src="https://github.com/user-attachments/assets/0a931045-9659-4cad-9285-1f2f754bbccb" />

**마지막 페이지인 경우**
<img width="400" alt="스크린샷 2025-01-20 오전 10 04 00" src="https://github.com/user-attachments/assets/8ddb078c-7e43-4f2b-b2ca-cf335fd65fa8" />


## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- 관련된 Discussion 등이 있다면 첨부해주세요


## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-177