### PR TITLE
[YS-182] config: 사용하지 않는 Naver OAuth scope 제거

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,7 +38,6 @@ spring:
             client-secret: ${NAVER_CLIENT_SECRET}
             scope:
               - email
-              - profile
             client-name: Naver
         provider:
           google:


### PR DESCRIPTION
## 💡 작업 내용
- 사용자의 개인정보는 최소한으로 사용해야 하므로 Naver OAuth scope 중 사용하지 않는 profile을 제거했습니다

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- 해당 PR은 단순 scope 제거이므로 리뷰를 받지 않고 바로 머지하겠습니다


## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-182