### PR TITLE
[YS-185] hotfix: NaverOAuth 응답 구조 수정

### DIFF
--- a/src/main/kotlin/com/dobby/backend/application/usecase/auth/FetchNaverUserInfoUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/auth/FetchNaverUserInfoUseCase.kt
@@ -34,7 +34,7 @@ class FetchNaverUserInfoUseCase(
     override fun execute(input: Input): Output {
         val oauthToken = naverAuthGateway.getAccessToken(input.authorizationCode, input.state).accessToken
         val userInfo = oauthToken?.let { naverAuthGateway.getUserInfo(it) }
-        val email = userInfo?.email
+        val email = userInfo?.response?.email
         val member = email?.let { memberGateway.findByOauthEmailAndStatus(it, MemberStatus.ACTIVE) }
 
         return if (member != null) {

--- a/src/main/kotlin/com/dobby/backend/infrastructure/feign/naver/NaverUserInfoFeignClient.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/feign/naver/NaverUserInfoFeignClient.kt
@@ -2,7 +2,7 @@ package com.dobby.backend.infrastructure.feign.naver
 
 import com.dobby.backend.presentation.api.dto.response.auth.naver.NaverInfoResponse
 import org.springframework.cloud.openfeign.FeignClient
-import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestHeader
 
 @FeignClient(
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RequestHeader
     url = "https://openapi.naver.com/v1/nid/me"
 )
 interface NaverUserInfoFeignClient {
-    @PostMapping
+    @GetMapping
     fun getUserInfo(
         @RequestHeader("Authorization") accessToken: String
     ): NaverInfoResponse

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/auth/naver/NaverInfoResponse.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/auth/naver/NaverInfoResponse.kt
@@ -3,6 +3,17 @@ package com.dobby.backend.presentation.api.dto.response.auth.naver
 import com.fasterxml.jackson.annotation.JsonProperty
 
 data class NaverInfoResponse(
+    @JsonProperty("resultcode")
+    val resultCode: String,
+
+    @JsonProperty("message")
+    val message: String,
+
+    @JsonProperty("response")
+    val response: NaverUserResponse
+)
+
+data class NaverUserResponse(
     @JsonProperty("email")
     val email: String
 )

--- a/src/main/resources/template-application-local.yml
+++ b/src/main/resources/template-application-local.yml
@@ -32,7 +32,6 @@ spring:
             client-secret: ${NAVER_CLIENT_SECRET}
             scope:
               - email
-              - profile
             client-name: Naver
         provider:
           google:

--- a/src/test/kotlin/com/dobby/backend/application/usecase/auth/FetchNaverUserInfoUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/auth/FetchNaverUserInfoUseCaseTest.kt
@@ -8,6 +8,7 @@ import com.dobby.backend.infrastructure.database.entity.enums.MemberStatus
 import com.dobby.backend.infrastructure.database.entity.enums.ProviderType
 import com.dobby.backend.infrastructure.database.entity.enums.RoleType
 import com.dobby.backend.presentation.api.dto.response.auth.naver.NaverTokenResponse
+import com.dobby.backend.presentation.api.dto.response.auth.naver.NaverUserResponse
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -45,7 +46,9 @@ class FetchNaverUserInfoUseCaseTest : BehaviorSpec({
         val mockNaverTokenResponse = NaverTokenResponse("mock-access-token")
         every { naverAuthGateway.getAccessToken(any(), any()) } returns mockNaverTokenResponse
         every { naverAuthGateway.getUserInfo("mock-access-token") } returns mockk {
-            every { email } returns "test@example.com"
+            every { response } returns NaverUserResponse(
+                email = "test@example.com"
+            )
         }
 
         every { tokenGateway.generateAccessToken(any()) } returns "mock-jwt-access-token"


### PR DESCRIPTION
## 💡 작업 내용
- NaverOAuth 응답 구조를 올바른 형태로 수정

<img width="430" alt="스크린샷 2025-01-20 오후 2 27 40" src="https://github.com/user-attachments/assets/0e48bd13-9baf-4ac5-be08-b29438e64770" />

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- **로컬에서 정상적으로 통신함을 확인하여 바로 머지합니다**


## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-185