### PR TITLE
[YS-186] refact: NaverOAuth email 관련 필드 not-null로 변경 및 자잘한 리팩터링

### DIFF
--- a/src/main/kotlin/com/dobby/backend/application/usecase/auth/FetchNaverUserInfoUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/auth/FetchNaverUserInfoUseCase.kt
@@ -19,23 +19,22 @@ class FetchNaverUserInfoUseCase(
         val state: String
     )
 
-    // TODO: 테스트 후, oauthEmail not null 처리
     data class Output(
         val isRegistered: Boolean,
         val accessToken: String?,
         val refreshToken: String?,
         val memberId: Long?,
         val name: String?,
-        val oauthEmail: String?,
+        val oauthEmail: String,
         val role: RoleType?,
         val provider: ProviderType
     )
 
     override fun execute(input: Input): Output {
         val oauthToken = naverAuthGateway.getAccessToken(input.authorizationCode, input.state).accessToken
-        val userInfo = oauthToken?.let { naverAuthGateway.getUserInfo(it) }
-        val email = userInfo?.response?.email
-        val member = email?.let { memberGateway.findByOauthEmailAndStatus(it, MemberStatus.ACTIVE) }
+        val userInfo = naverAuthGateway.getUserInfo(oauthToken)
+        val email = userInfo.response.email
+        val member = email.let { memberGateway.findByOauthEmailAndStatus(it, MemberStatus.ACTIVE) }
 
         return if (member != null) {
             val jwtAccessToken = jwtTokenGateway.generateAccessToken(member)

--- a/src/main/kotlin/com/dobby/backend/application/usecase/auth/GenerateTestTokenUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/auth/GenerateTestTokenUseCase.kt
@@ -1,6 +1,7 @@
 package com.dobby.backend.application.usecase.auth
 
 import com.dobby.backend.application.usecase.UseCase
+import com.dobby.backend.domain.exception.MemberNotFoundException
 import com.dobby.backend.domain.gateway.member.MemberGateway
 import com.dobby.backend.domain.gateway.auth.TokenGateway
 import com.dobby.backend.domain.model.member.Member
@@ -21,7 +22,9 @@ class GenerateTestTokenUseCase(
 
     override fun execute(input: Input): Output {
         val memberId = input.memberId
-        val member = memberGateway.getById(memberId)
+        val member = memberGateway.findById(memberId)
+            ?: throw MemberNotFoundException()
+
         return Output(
             accessToken = tokenGateway.generateAccessToken(member),
             refreshToken = tokenGateway.generateRefreshToken(member),

--- a/src/main/kotlin/com/dobby/backend/domain/gateway/auth/NaverAuthGateway.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/gateway/auth/NaverAuthGateway.kt
@@ -5,5 +5,5 @@ import com.dobby.backend.presentation.api.dto.response.auth.naver.NaverTokenResp
 
 interface NaverAuthGateway {
     fun getAccessToken(authorizationCode: String, state: String): NaverTokenResponse
-    fun getUserInfo(accessToken: String): NaverInfoResponse?
+    fun getUserInfo(accessToken: String): NaverInfoResponse
 }

--- a/src/main/kotlin/com/dobby/backend/domain/gateway/member/MemberGateway.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/gateway/member/MemberGateway.kt
@@ -5,6 +5,7 @@ import com.dobby.backend.infrastructure.database.entity.enums.MemberStatus
 
 interface MemberGateway {
     fun getById(memberId: Long): Member
+    fun findById(memberId: Long): Member?
     fun findByOauthEmailAndStatus(email: String, status: MemberStatus): Member?
     fun findByOauthEmail(email: String): Member?
     fun save(savedMember: Member) : Member

--- a/src/main/kotlin/com/dobby/backend/infrastructure/gateway/auth/NaverAuthGatewayImpl.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/gateway/auth/NaverAuthGatewayImpl.kt
@@ -25,7 +25,7 @@ class NaverAuthGatewayImpl(
         )
     }
 
-    override fun getUserInfo(accessToken: String): NaverInfoResponse? {
+    override fun getUserInfo(accessToken: String): NaverInfoResponse {
         return naverUserInfoFeignClient.getUserInfo("Bearer $accessToken")
     }
 }

--- a/src/main/kotlin/com/dobby/backend/infrastructure/gateway/member/MemberGatewayImpl.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/gateway/member/MemberGatewayImpl.kt
@@ -18,6 +18,13 @@ class MemberGatewayImpl(
             .let(MemberEntity::toDomain)
     }
 
+    override fun findById(memberId: Long): Member? {
+        return memberRepository
+            .findById(memberId)
+            .map(MemberEntity::toDomain)
+            .orElse(null)
+    }
+
     override fun findByOauthEmailAndStatus(email: String, status: MemberStatus): Member? {
         return memberRepository
             .findByOauthEmailAndStatus(email, status)

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/auth/naver/NaverTokenResponse.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/auth/naver/NaverTokenResponse.kt
@@ -4,5 +4,5 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class NaverTokenResponse (
     @JsonProperty("access_token")
-    val accessToken: String?
+    val accessToken: String
 )

--- a/src/test/kotlin/com/dobby/backend/application/usecase/auth/GenerateTestTokenUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/auth/GenerateTestTokenUseCaseTest.kt
@@ -1,5 +1,6 @@
 package com.dobby.backend.application.usecase.auth
 
+import com.dobby.backend.domain.exception.MemberNotFoundException
 import com.dobby.backend.domain.gateway.member.MemberGateway
 import io.kotest.core.spec.style.BehaviorSpec
 import com.dobby.backend.domain.gateway.auth.TokenGateway
@@ -7,6 +8,7 @@ import com.dobby.backend.domain.model.member.Member
 import com.dobby.backend.infrastructure.database.entity.enums.MemberStatus
 import com.dobby.backend.infrastructure.database.entity.enums.ProviderType
 import com.dobby.backend.infrastructure.database.entity.enums.RoleType
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
@@ -26,7 +28,7 @@ class GenerateTestTokenUseCaseTest: BehaviorSpec({
 
         every { tokenGateway.generateAccessToken(member) } returns accessToken
         every { tokenGateway.generateRefreshToken(member) } returns refreshToken
-        every { memberGateway.getById(1) } returns member
+        every { memberGateway.findById(1) } returns member
 
         `when`("execute가 호출되면") {
             val input = GenerateTestTokenUseCase.Input(member.id)
@@ -35,6 +37,18 @@ class GenerateTestTokenUseCaseTest: BehaviorSpec({
             then("생성된 accessToken과 refreshToken이 반환되어야 한다") {
                 result.accessToken shouldBe accessToken
                 result.refreshToken shouldBe refreshToken
+            }
+        }
+
+        every { memberGateway.findById(2) } returns null
+
+        `when`("존재하지 않는 회원 ID가 주어졌을 때") {
+            val input = GenerateTestTokenUseCase.Input(2)
+
+            then("MemberNotFoundException 예외가 던져져야 한다") {
+                shouldThrow<MemberNotFoundException> {
+                    generateTestTokenUseCase.execute(input)
+                }
             }
         }
     }


### PR DESCRIPTION
## 💡 작업 내용
- 테스트를 위해 nullable로 설정했던 NaverOAuth email 관련 필드를 not-null로 변경
- 디스코드 에러 알림을 dev / prod 환경에서만 전송하도록 수정
- 테스트 토큰 강제 발급 관련 예외 처리 로직 추가

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- 관련된 Discussion 등이 있다면 첨부해주세요


## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-186

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
    - 없음

- **버그 수정**
    - Naver 인증 및 토큰 처리의 안정성 개선
    - 회원 조회 로직 강화 및 예외 처리 추가

- **리팩터링**
    - 타입 안전성 강화: 일부 nullable 타입을 non-nullable로 변경
    - 예외 처리 메커니즘 개선
    - 환경별 오류 알림 로직 최적화

- **테스트**
    - 존재하지 않는 회원 ID에 대한 테스트 케이스 추가

주요 변경사항은 인증 및 회원 관리 프로세스의 안정성과 오류 처리를 강화하는 데 중점을 두고 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->