### PR TITLE
[YS-187] refact: Auth 관련 응답 매핑 로직을 Mapper 클래스로 분리

### DIFF
--- a/src/main/kotlin/com/dobby/backend/application/service/AuthService.kt
+++ b/src/main/kotlin/com/dobby/backend/application/service/AuthService.kt
@@ -14,68 +14,21 @@ class AuthService(
     private val generateTokenWithRefreshTokenUseCase: GenerateTokenWithRefreshTokenUseCase,
     private val generateTestTokenUseCase: GenerateTestTokenUseCase,
 ) {
-    fun getGoogleUserInfo(authorizationCode: String): FetchGoogleUserInfoUseCase.Output {
-        val result = fetchGoogleUserInfoUseCase.execute(
-            FetchGoogleUserInfoUseCase.Input(
-                authorizationCode = authorizationCode
-            )
-        )
-        return FetchGoogleUserInfoUseCase.Output(
-            isRegistered = result.isRegistered,
-            accessToken = result.accessToken,
-            refreshToken = result.refreshToken,
-            memberId = result.memberId,
-            name = result.name,
-            oauthEmail = result.oauthEmail,
-            role = result.role,
-            provider = result.provider,
-        )
+    fun getGoogleUserInfo(input: FetchGoogleUserInfoUseCase.Input): FetchGoogleUserInfoUseCase.Output {
+        return fetchGoogleUserInfoUseCase.execute(input)
     }
 
-    fun getNaverUserInfo(authorizationCode: String, state: String): FetchNaverUserInfoUseCase.Output {
-        val result = fetchNaverUserInfoUseCase.execute(
-            FetchNaverUserInfoUseCase.Input(
-                authorizationCode = authorizationCode,
-                state = state
-            )
-        )
-        return FetchNaverUserInfoUseCase.Output(
-            isRegistered = result.isRegistered,
-            accessToken = result.accessToken,
-            refreshToken = result.refreshToken,
-            memberId = result.memberId,
-            name = result.name,
-            oauthEmail = result.oauthEmail,
-            role = result.role,
-            provider = result.provider,
-        )
+    fun getNaverUserInfo(input: FetchNaverUserInfoUseCase.Input): FetchNaverUserInfoUseCase.Output {
+        return fetchNaverUserInfoUseCase.execute(input)
     }
 
     @Transactional
-    fun forceToken(memberId: Long): GenerateTestTokenUseCase.Output {
-        val result = generateTestTokenUseCase.execute(
-            GenerateTestTokenUseCase.Input(
-                memberId = memberId
-            )
-        )
-        return GenerateTestTokenUseCase.Output(
-            accessToken = result.accessToken,
-            refreshToken = result.refreshToken,
-            member = result.member
-        )
+    fun forceToken(input: GenerateTestTokenUseCase.Input): GenerateTestTokenUseCase.Output {
+        return generateTestTokenUseCase.execute(input)
     }
 
     @Transactional
-    fun signInWithRefreshToken(refreshToken: String): GenerateTokenWithRefreshTokenUseCase.Output {
-        val result = generateTokenWithRefreshTokenUseCase.execute(
-            GenerateTokenWithRefreshTokenUseCase.Input(
-                refreshToken = refreshToken,
-            )
-        )
-        return GenerateTokenWithRefreshTokenUseCase.Output(
-            accessToken = result.accessToken,
-            refreshToken = result.refreshToken,
-            member = result.member
-        )
+    fun signInWithRefreshToken(input: GenerateTokenWithRefreshTokenUseCase.Input): GenerateTokenWithRefreshTokenUseCase.Output {
+        return generateTokenWithRefreshTokenUseCase.execute(input)
     }
 }

--- a/src/main/kotlin/com/dobby/backend/presentation/api/mapper/AuthMapper.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/mapper/AuthMapper.kt
@@ -76,7 +76,7 @@ object AuthMapper {
 
     fun toSignInWithRefreshTokenResponse(output: GenerateTokenWithRefreshTokenUseCase.Output): OauthLoginResponse {
         return OauthLoginResponse(
-            isRegistered = false,
+            isRegistered = true,
             accessToken = output.accessToken,
             refreshToken = output.refreshToken,
             memberInfo = MemberResponse(

--- a/src/main/kotlin/com/dobby/backend/presentation/api/mapper/AuthMapper.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/mapper/AuthMapper.kt
@@ -1,0 +1,91 @@
+package com.dobby.backend.presentation.api.mapper
+
+import com.dobby.backend.application.usecase.auth.FetchGoogleUserInfoUseCase
+import com.dobby.backend.application.usecase.auth.FetchNaverUserInfoUseCase
+import com.dobby.backend.application.usecase.auth.GenerateTestTokenUseCase
+import com.dobby.backend.application.usecase.auth.GenerateTokenWithRefreshTokenUseCase
+import com.dobby.backend.presentation.api.dto.response.auth.OauthLoginResponse
+import com.dobby.backend.presentation.api.dto.response.auth.TestMemberSignInResponse
+import com.dobby.backend.presentation.api.dto.response.member.MemberResponse
+import com.dobby.backend.presentation.api.dto.request.auth.GoogleOauthLoginRequest
+import com.dobby.backend.presentation.api.dto.request.auth.MemberRefreshTokenRequest
+import com.dobby.backend.presentation.api.dto.request.auth.NaverOauthLoginRequest
+
+object AuthMapper {
+    fun toGoogleOauthLoginInput(request: GoogleOauthLoginRequest): FetchGoogleUserInfoUseCase.Input {
+        return FetchGoogleUserInfoUseCase.Input(
+            authorizationCode = request.authorizationCode
+        )
+    }
+
+    fun toGoogleOauthLoginResponse(output: FetchGoogleUserInfoUseCase.Output): OauthLoginResponse {
+        return OauthLoginResponse(
+            isRegistered = output.isRegistered,
+            accessToken = output.accessToken,
+            refreshToken = output.refreshToken,
+            memberInfo = MemberResponse(
+                memberId = output.memberId,
+                name = output.name,
+                oauthEmail = output.oauthEmail,
+                role = output.role,
+                provider = output.provider
+            )
+        )
+    }
+
+    fun toNaverOauthLoginInput(request: NaverOauthLoginRequest): FetchNaverUserInfoUseCase.Input {
+        return FetchNaverUserInfoUseCase.Input(
+            authorizationCode = request.authorizationCode,
+            state = request.state
+        )
+    }
+
+    fun toNaverOauthLoginResponse(output: FetchNaverUserInfoUseCase.Output): OauthLoginResponse {
+        return OauthLoginResponse(
+            isRegistered = output.isRegistered,
+            accessToken = output.accessToken,
+            refreshToken = output.refreshToken,
+            memberInfo = MemberResponse(
+                memberId = output.memberId,
+                name = output.name,
+                oauthEmail = output.oauthEmail,
+                role = output.role,
+                provider = output.provider
+            )
+        )
+    }
+
+    fun toForceTokenInput(input: Long): GenerateTestTokenUseCase.Input {
+        return GenerateTestTokenUseCase.Input(
+            memberId = input
+        )
+    }
+
+    fun toTestMemberSignInResponse(output: GenerateTestTokenUseCase.Output): TestMemberSignInResponse {
+        return TestMemberSignInResponse(
+            accessToken = output.accessToken,
+            refreshToken = output.refreshToken
+        )
+    }
+
+    fun toSignInWithRefreshTokenInput(request: MemberRefreshTokenRequest): GenerateTokenWithRefreshTokenUseCase.Input {
+        return GenerateTokenWithRefreshTokenUseCase.Input(
+            refreshToken = request.refreshToken
+        )
+    }
+
+    fun toSignInWithRefreshTokenResponse(output: GenerateTokenWithRefreshTokenUseCase.Output): OauthLoginResponse {
+        return OauthLoginResponse(
+            isRegistered = false,
+            accessToken = output.accessToken,
+            refreshToken = output.refreshToken,
+            memberInfo = MemberResponse(
+                memberId = output.member.id,
+                name = output.member.name,
+                oauthEmail = output.member.oauthEmail,
+                role = output.member.role,
+                provider = output.member.provider
+            )
+        )
+    }
+}


### PR DESCRIPTION
## 💡 작업 내용
- Auth 관련 응답 매핑 로직을 이전에 협의한 규칙에 맞게 Mapper 클래스로 분리

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- 정상적으로 동작하는지 확인했습니다


## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-187

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **리팩토링**
	- 인증 서비스의 메서드 시그니처 간소화
	- OAuth 로그인 및 토큰 처리 로직 개선
	- 매퍼(Mapper) 클래스를 통한 요청/응답 변환 로직 분리

- **새로운 기능**
	- 새로운 `AuthMapper` 객체 추가로 인증 관련 데이터 변환 기능 강화

- **개선 사항**
	- 코드 가독성 및 유지보수성 향상
	- 인증 프로세스의 모듈성 증대
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
