### PR TITLE
[YS-178] feat: 실험자가 작성한 공고 게시글 삭제 API 구현

### DIFF
--- a/src/main/kotlin/com/dobby/backend/application/service/ExperimentPostService.kt
+++ b/src/main/kotlin/com/dobby/backend/application/service/ExperimentPostService.kt
@@ -21,7 +21,8 @@ class ExperimentPostService(
     private val getExperimentPostApplyMethodUseCase: GetExperimentPostApplyMethodUseCase,
     private val generateExperimentPostPreSignedUrlUseCase: GenerateExperimentPostPreSignedUrlUseCase,
     private val updateExpiredExperimentPostUseCase: UpdateExpiredExperimentPostUseCase,
-    private val getExperimentPostTotalCountByCustomFilterUseCase: GetExperimentPostTotalCountByCustomFilterUseCase
+    private val getExperimentPostTotalCountByCustomFilterUseCase: GetExperimentPostTotalCountByCustomFilterUseCase,
+    private val deleteExperimentPostUseCase: DeleteExperimentPostUseCase
 ) {
     @Transactional
     fun createNewExperimentPost(input: CreateExperimentPostUseCase.Input): CreateExperimentPostUseCase.Output {
@@ -82,5 +83,9 @@ class ExperimentPostService(
 
     fun getExperimentPostTotalCount(input: GetExperimentPostTotalCountByCustomFilterUseCase.Input): Int {
         return getExperimentPostTotalCountByCustomFilterUseCase.execute(input)
+    }
+
+    fun deleteExperimentPost(input: DeleteExperimentPostUseCase.Input) {
+        deleteExperimentPostUseCase.execute(input)
     }
 }

--- a/src/main/kotlin/com/dobby/backend/application/service/ExperimentPostService.kt
+++ b/src/main/kotlin/com/dobby/backend/application/service/ExperimentPostService.kt
@@ -85,6 +85,7 @@ class ExperimentPostService(
         return getExperimentPostTotalCountByCustomFilterUseCase.execute(input)
     }
 
+    @Transactional
     fun deleteExperimentPost(input: DeleteExperimentPostUseCase.Input) {
         deleteExperimentPostUseCase.execute(input)
     }

--- a/src/main/kotlin/com/dobby/backend/application/usecase/experiment/DeleteExperimentPostUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/experiment/DeleteExperimentPostUseCase.kt
@@ -1,0 +1,23 @@
+package com.dobby.backend.application.usecase.experiment
+
+import com.dobby.backend.application.usecase.UseCase
+import com.dobby.backend.domain.exception.ExperimentPostNotFoundException
+import com.dobby.backend.domain.gateway.experiment.ExperimentPostGateway
+
+class DeleteExperimentPostUseCase(
+    private val experimentPostGateway: ExperimentPostGateway
+): UseCase<DeleteExperimentPostUseCase.Input, Unit> {
+    data class Input(
+        val memberId: Long,
+        val postId: Long
+    )
+
+    override fun execute(input: Input) {
+        val post = experimentPostGateway.findExperimentPostByMemberIdAndPostId(
+            memberId = input.memberId,
+            postId = input.postId
+        ) ?: throw ExperimentPostNotFoundException()
+
+        experimentPostGateway.delete(post)
+    }
+}

--- a/src/main/kotlin/com/dobby/backend/domain/gateway/experiment/ExperimentPostGateway.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/gateway/experiment/ExperimentPostGateway.kt
@@ -24,4 +24,5 @@ interface ExperimentPostGateway {
     fun countExperimentPostsByMemberId(memberId: Long): Int
     fun findExperimentPostByMemberIdAndPostId(memberId: Long, postId: Long): ExperimentPost?
     fun countExperimentPostsByCustomFilter(customFilter: CustomFilter): Int
+    fun delete(post: ExperimentPost)
 }

--- a/src/main/kotlin/com/dobby/backend/infrastructure/gateway/experiment/ExperimentPostGatewayImpl.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/gateway/experiment/ExperimentPostGatewayImpl.kt
@@ -104,6 +104,6 @@ class ExperimentPostGatewayImpl(
     }
 
     override fun delete(post: ExperimentPost) {
-        experimentPostRepository.delete(ExperimentPostConverter.toEntity(post))
+        experimentPostRepository.delete(ExperimentPostEntity.fromDomain(post))
     }
 }

--- a/src/main/kotlin/com/dobby/backend/infrastructure/gateway/experiment/ExperimentPostGatewayImpl.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/gateway/experiment/ExperimentPostGatewayImpl.kt
@@ -102,4 +102,8 @@ class ExperimentPostGatewayImpl(
     override fun countExperimentPostsByCustomFilter(customFilter: CustomFilter): Int {
         return experimentPostCustomRepository.countExperimentPostsByCustomFilter(customFilter)
     }
+
+    override fun delete(post: ExperimentPost) {
+        experimentPostRepository.delete(ExperimentPostConverter.toEntity(post))
+    }
 }

--- a/src/main/kotlin/com/dobby/backend/presentation/api/controller/ExperimentPostController.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/controller/ExperimentPostController.kt
@@ -16,6 +16,7 @@ import com.dobby.backend.presentation.api.dto.response.experiment.CreateExperime
 import com.dobby.backend.presentation.api.dto.response.experiment.ExperimentPostApplyMethodResponse
 import com.dobby.backend.presentation.api.dto.response.experiment.ExperimentPostCountsResponse
 import com.dobby.backend.presentation.api.dto.response.experiment.ExperimentPostDetailResponse
+import com.dobby.backend.presentation.api.dto.response.member.DefaultResponse
 import com.dobby.backend.presentation.api.mapper.ExperimentPostMapper
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -42,6 +43,20 @@ class ExperimentPostController (
         val input = ExperimentPostMapper.toCreatePostUseCaseInput(request)
         val output = experimentPostService.createNewExperimentPost(input)
         return ExperimentPostMapper.toCreateExperimentPostResponse(output)
+    }
+
+    @PreAuthorize("hasRole('RESEARCHER')")
+    @DeleteMapping("/{postId}")
+    @Operation(
+        summary = "공고 삭제 API- 연구자 공고 삭제",
+        description = "연구자가 자신이 등록한 실험 공고를 삭제합니다."
+    )
+    fun deleteExperimentPost(
+        @PathVariable postId: Long
+    ): DefaultResponse {
+        val input = ExperimentPostMapper.toDeleteExperimentPostUseCaseInput(postId)
+        experimentPostService.deleteExperimentPost(input)
+        return DefaultResponse.ok()
     }
 
     @PreAuthorize("hasRole('RESEARCHER')")

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/member/DefaultResponse.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/member/DefaultResponse.kt
@@ -1,0 +1,14 @@
+package com.dobby.backend.presentation.api.dto.response.member
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "기본 Operation 응답")
+data class DefaultResponse(
+    @Schema(description = "성공 유무", example = "true")
+    val success: Boolean
+) {
+    companion object {
+        fun ok(): DefaultResponse = DefaultResponse(true)
+        fun fail(): DefaultResponse = DefaultResponse(false)
+    }
+}

--- a/src/main/kotlin/com/dobby/backend/presentation/api/mapper/ExperimentPostMapper.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/mapper/ExperimentPostMapper.kt
@@ -203,7 +203,7 @@ object ExperimentPostMapper {
     }
 
 
-   fun toGetExperimentPostsResponse(
+    fun toGetExperimentPostsResponse(
         output: List<GetExperimentPostsUseCase.Output>,
         page: Int,
         totalCount: Int,
@@ -261,6 +261,13 @@ object ExperimentPostMapper {
                 )
             },
             recruitStatus = customFilter.recruitStatus
+        )
+    }
+
+    fun toDeleteExperimentPostUseCaseInput(postId: Long): DeleteExperimentPostUseCase.Input {
+        return DeleteExperimentPostUseCase.Input(
+            memberId = getCurrentMemberId(),
+            postId = postId
         )
     }
 }

--- a/src/test/kotlin/com/dobby/backend/application/usecase/experiment/DeleteExperimentPostUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/experiment/DeleteExperimentPostUseCaseTest.kt
@@ -1,0 +1,52 @@
+package com.dobby.backend.application.usecase.experiment
+
+import com.dobby.backend.domain.exception.ExperimentPostNotFoundException
+import com.dobby.backend.domain.gateway.experiment.ExperimentPostGateway
+import com.dobby.backend.domain.model.experiment.ExperimentPost
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+class DeleteExperimentPostUseCaseTest : BehaviorSpec({
+
+    val experimentPostGateway = mockk<ExperimentPostGateway>()
+    val deleteExperimentPostUseCase = DeleteExperimentPostUseCase(experimentPostGateway)
+
+    given("게시글을 삭제할 때") {
+        val memberId = 1L
+        val postId = 2L
+        val input = DeleteExperimentPostUseCase.Input(memberId, postId)
+
+        val existingPost = mockk<ExperimentPost>()
+        every { experimentPostGateway.findExperimentPostByMemberIdAndPostId(memberId, postId) } returns existingPost
+
+        `when`("게시글이 존재하면") {
+            every { experimentPostGateway.delete(existingPost) } returns Unit
+
+            then("게시글을 삭제하고 아무 값도 반환하지 않아야 한다") {
+                deleteExperimentPostUseCase.execute(input)
+                verify(exactly = 1) { experimentPostGateway.findExperimentPostByMemberIdAndPostId(memberId, postId) }
+                verify(exactly = 1) { experimentPostGateway.delete(existingPost) }
+            }
+        }
+    }
+
+    given("게시글을 삭제하려는데 게시글이 존재하지 않는 경우") {
+        val memberId = 1L
+        val postId = 999L
+        val input = DeleteExperimentPostUseCase.Input(memberId, postId)
+
+        every { experimentPostGateway.findExperimentPostByMemberIdAndPostId(memberId, postId) } returns null
+
+        `when`("게시글을 찾지 못하면") {
+            then("ExperimentPostNotFoundException 예외가 발생해야 한다") {
+                shouldThrow<ExperimentPostNotFoundException> {
+                    deleteExperimentPostUseCase.execute(input)
+                }
+                verify(exactly = 1) { experimentPostGateway.findExperimentPostByMemberIdAndPostId(memberId, postId) }
+            }
+        }
+    }
+})


### PR DESCRIPTION
## 💡 작업 내용
- 실험자가 작성한 공고 삭제 API 구현

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- API 호출 테스트를 했을 때, `cascade = [CascadeType.ALL]`로 인해 ExperimentPost와 연관된 엔티티들까지 같이 삭제됨을 확인했습니다


## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-178

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **새로운 기능**
	- 실험 게시물 삭제 기능 추가
	- 연구자 역할을 가진 사용자만 게시물 삭제 가능

- **버그 수정**
	- 존재하지 않는 게시물 삭제 시 오류 처리 메커니즘 구현

- **테스트**
	- 실험 게시물 삭제 기능에 대한 단위 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-178