### PR TITLE
fix: recuritStatus 컬럼명 변경에 따른 스케줄러의 모집 상태 변경 로직을 `true->false`로 수정

### DIFF
--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/repository/ExperimentPostCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/repository/ExperimentPostCustomRepositoryImpl.kt
@@ -118,10 +118,10 @@ class ExperimentPostCustomRepositoryImpl (
         val experimentPost = QExperimentPostEntity.experimentPostEntity
 
         return jpaQueryFactory.update(experimentPost)
-            .set(experimentPost.recruitStatus, true)
+            .set(experimentPost.recruitStatus, false)
             .where(
                 experimentPost.endDate.lt(currentDate)
-                    .and(experimentPost.recruitStatus.eq(false))
+                    .and(experimentPost.recruitStatus.eq(true))
             )
             .execute()
     }


### PR DESCRIPTION
## 💡 작업 내용
- recuritStatus 컬럼명 변경에 따른 스케줄러 로직을 `true->false`로 수정

## ✅ 셀프 체크리스트
- [ ] PR 제목을 형식에 맞게 작성했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [ ] 테스트는 잘 통과했나요?
- [ ] 빌드에 성공했나요?
- [ ] 본인을 assign 해주세요.
- [ ] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- 관련된 Discussion 등이 있다면 첨부해주세요
