### PR TITLE
[YS-122] 연구자 회원 정보 조회 API 구현

### DIFF
--- a/src/main/kotlin/com/dobby/backend/application/usecase/member/GetResearcherInfoUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/member/GetResearcherInfoUseCase.kt
@@ -3,6 +3,9 @@ package com.dobby.backend.application.usecase.member
 import com.dobby.backend.application.usecase.UseCase
 import com.dobby.backend.domain.exception.ResearcherNotFoundException
 import com.dobby.backend.domain.gateway.member.ResearcherGateway
+import com.dobby.backend.domain.model.member.Member
+import com.dobby.backend.presentation.api.dto.response.member.MemberResponse
+import io.swagger.v3.oas.annotations.media.Schema
 
 class GetResearcherInfoUseCase(
     private val researcherGateway: ResearcherGateway
@@ -12,7 +15,11 @@ class GetResearcherInfoUseCase(
     )
 
     data class Output(
+        val member : Member,
+        val univEmail: String,
         val univName: String,
+        val major: String,
+        val labInfo: String?,
         val leadResearcher: String,
     )
 
@@ -24,7 +31,11 @@ class GetResearcherInfoUseCase(
                 " " +researcher.labInfo+ " " +researcher.member.name
 
         return Output(
-            univName =researcher.univName,
+            member = researcher.member,
+            univEmail = researcher.univEmail,
+            univName = researcher.univName,
+            major = researcher.major,
+            labInfo = researcher.labInfo,
             leadResearcher = leadResearcher
         )
     }

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/member/ParticipantInfoResponse.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/member/ParticipantInfoResponse.kt
@@ -5,7 +5,7 @@ import com.dobby.backend.infrastructure.database.entity.enums.MatchType
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 
-@Schema(description = "공고 등록 시, 자동 입력에 필요한 연구자 정보 반환 DTO")
+@Schema(description = "공고 등록 시, 자동 입력에 필요한 참여자 정보 반환 DTO")
 data class ParticipantInfoResponse(
     @Schema(description = "사용자 기본 정보")
     val memberInfo: MemberResponse,

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/member/ResearcherInfoResponse.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/member/ResearcherInfoResponse.kt
@@ -17,7 +17,7 @@ data class ResearcherInfoResponse(
     val major: String,
 
     @Schema(description = "연구실 정보")
-    val labInfo: String,
+    val labInfo: String?,
 
     @Schema(description = "연구 책임")
     val leadResearcher: String,

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/member/ResearcherInfoResponse.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/member/ResearcherInfoResponse.kt
@@ -2,11 +2,23 @@ package com.dobby.backend.presentation.api.dto.response.member
 
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(description = "공고 등록 시, 자동 입력에 필요한 연구자 정보 반환 DTO")
+@Schema(description = "연구자 정보 조회 DTO")
 data class ResearcherInfoResponse(
-    @Schema(description = "연구 책임")
-    val leadResearcher: String,
+    @Schema(description = "사용자 기본 정보")
+    val memberInfo: MemberResponse,
+
+    @Schema(description = "대학교 메일")
+    val univEmail: String,
 
     @Schema(description = "대학교 이름")
     val univName: String,
+
+    @Schema(description = "대학교 전공")
+    val major: String,
+
+    @Schema(description = "연구실 정보")
+    val labInfo: String,
+
+    @Schema(description = "연구 책임")
+    val leadResearcher: String,
 )

--- a/src/main/kotlin/com/dobby/backend/presentation/api/mapper/MemberMapper.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/mapper/MemberMapper.kt
@@ -93,8 +93,12 @@ object MemberMapper {
 
     fun toResearcherInfoResponse(response: GetResearcherInfoUseCase.Output): ResearcherInfoResponse {
         return ResearcherInfoResponse(
-            leadResearcher = response.leadResearcher,
-            univName = response.univName
+            memberInfo = MemberResponse.fromDomain(response.member),
+            univEmail = response.univEmail,
+            univName = response.univName,
+            major = response.major,
+            labInfo = response.labInfo,
+            leadResearcher = response.leadResearcher
         )
     }
 

--- a/src/test/kotlin/com/dobby/backend/application/usecase/member/GetResearcherInfoUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/member/GetResearcherInfoUseCaseTest.kt
@@ -1,0 +1,79 @@
+package com.dobby.backend.application.usecase.member
+
+import com.dobby.backend.domain.exception.ResearcherNotFoundException
+import com.dobby.backend.domain.gateway.member.ResearcherGateway
+import com.dobby.backend.domain.model.member.Member
+import com.dobby.backend.domain.model.member.Researcher
+import com.dobby.backend.infrastructure.database.entity.enums.MemberStatus
+import com.dobby.backend.infrastructure.database.entity.enums.ProviderType
+import com.dobby.backend.infrastructure.database.entity.enums.RoleType
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
+import io.mockk.mockk
+import java.time.LocalDateTime
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class GetResearcherInfoUseCaseTest : BehaviorSpec({
+    Given("Gateway에 유효한 memberId와 researcherId가 있다면") {
+        val researcherGateway = mockk<ResearcherGateway>()
+        val useCase = GetResearcherInfoUseCase(researcherGateway)
+
+        val input = GetResearcherInfoUseCase.Input(memberId = 1L)
+        val mockMember = Member(
+            id = 1L,
+            name = "신수정",
+            oauthEmail = "christer10@ewhain.net",
+            contactEmail = "christer10@naver.com",
+            provider = ProviderType.GOOGLE,
+            role = RoleType.RESEARCHER,
+            status = MemberStatus.ACTIVE,
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now()
+        )
+        val mockResearcher = Researcher(
+            member = mockMember,
+            id = 1L,
+            univEmail = "christer10@ewhain.net",
+            univName = "이화여자대학교",
+            major = "컴퓨터공학과",
+            labInfo = "야뿌 서버 연구실",
+            emailVerified = true,
+        )
+
+        every { researcherGateway.findByMemberId(input.memberId) } returns mockResearcher
+
+        `when`("GetResearcherInfoUseCase가 실행되면") {
+            val result = useCase.execute(input)
+
+            then("올바른 연구자 정보를 반환한다") {
+                assertEquals(mockResearcher.member, result.member)
+                assertEquals(mockResearcher.univEmail, result.univEmail)
+                assertEquals(mockResearcher.univName, result.univName)
+                assertEquals(mockResearcher.major, result.major)
+                assertEquals(mockResearcher.labInfo, result.labInfo)
+                assertEquals(
+                    "이화여자대학교 컴퓨터공학과 야뿌 서버 연구실 신수정",
+                    result.leadResearcher
+                )
+            }
+        }
+    }
+
+    given("gateway에 해당 member 정보가 없으면") {
+        val researcherGateway = mockk<ResearcherGateway>()
+        val useCase = GetResearcherInfoUseCase(researcherGateway)
+
+        val input = GetResearcherInfoUseCase.Input(memberId = 2L)
+
+        every { researcherGateway.findByMemberId(input.memberId) } returns null
+
+        `when`("GetResearcherInfoUseCase가 실행됐을때") {
+            then("ResearcherNotFoundException 예외가 반환된다.") {
+                assertFailsWith<ResearcherNotFoundException> {
+                    useCase.execute(input)
+                }
+            }
+        }
+    }
+})


### PR DESCRIPTION
## 💡 작업 내용
-기존 '연구자 정보를 렌더링'하는 역할에서 시작했던 `/v1/researchers/me` API를 리팩터링하여, '회원 정보 조회 API'로 통합했습니다.
![image](https://github.com/user-attachments/assets/55456b00-0df3-4959-a160-61f9ccd13182)


## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- 관련된 Discussion 등이 있다면 첨부해주세요
