### PR TITLE
[YS-210] hotfix: 참여자 회원가입 API matchType nullable로 변경

### DIFF
--- a/src/main/kotlin/com/dobby/backend/application/usecase/member/CreateParticipantUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/member/CreateParticipantUseCase.kt
@@ -26,7 +26,7 @@ class CreateParticipantUseCase (
         val birthDate: LocalDate,
         var basicAddressInfo: AddressInfo,
         var additionalAddressInfo: AddressInfo,
-        var matchType: MatchType,
+        var matchType: MatchType?,
     )
     data class AddressInfo(
         val region: Region,

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/member/ParticipantSignupRequest.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/member/ParticipantSignupRequest.kt
@@ -48,5 +48,5 @@ data class ParticipantSignupRequest(
     var additionalAddressInfo: AddressInfoResponse?,
 
     @Schema(description = "선호 실험 진행 방식")
-    var matchType: MatchType,
+    var matchType: MatchType?,
 )


### PR DESCRIPTION
## 💡 작업 내용
- **참여자 회원가입 시, `MatchType`을 nullable한 값으로 변경**

- `MatchType` 을 nullable한 값으로 요청해도, 참여자 회원가입이 정상적으로 될 수 있도록 버그를 수정했습니다.
![image](https://github.com/user-attachments/assets/a77010bc-dc90-4aa4-bad2-0d0c855fc065)

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
**- 엔티티 레벨에서 건드는 것이 아니기에, 로컬에서 잘 돌아감을 확인하고 바로 머지하겠습니다.**

## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-210

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **기능 변경**
  - 참가자 생성 및 가입 요청 시 `matchType` 속성을 선택적(nullable)으로 변경
  - 이제 `matchType`을 필수가 아닌 선택적 값으로 처리 가능

<!-- end of auto-generated comment: release notes by coderabbit.ai -->