### PR TITLE
[YS-223] fix: 서로 다른 Role에 대해 로그인 시도 시 에러 처리

### DIFF
--- a/src/main/kotlin/com/dobby/backend/application/usecase/auth/FetchGoogleUserInfoUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/auth/FetchGoogleUserInfoUseCase.kt
@@ -1,6 +1,9 @@
 package com.dobby.backend.application.usecase.auth
 
 import com.dobby.backend.application.usecase.UseCase
+import com.dobby.backend.domain.exception.ErrorCode
+import com.dobby.backend.domain.exception.MemberException
+import com.dobby.backend.domain.exception.SignInRoleMismatchException
 import com.dobby.backend.domain.gateway.member.MemberGateway
 import com.dobby.backend.domain.gateway.auth.TokenGateway
 import com.dobby.backend.domain.gateway.auth.GoogleAuthGateway
@@ -15,7 +18,8 @@ class FetchGoogleUserInfoUseCase(
 ) : UseCase<FetchGoogleUserInfoUseCase.Input, FetchGoogleUserInfoUseCase.Output> {
 
     data class Input(
-        val authorizationCode: String
+        val authorizationCode: String,
+        val role: RoleType
     )
 
     data class Output(
@@ -38,6 +42,9 @@ class FetchGoogleUserInfoUseCase(
         return if (member != null) {
             val jwtAccessToken = jwtTokenGateway.generateAccessToken(member)
             val jwtRefreshToken = jwtTokenGateway.generateRefreshToken(member)
+
+            if(member.role != input.role)
+                throw SignInRoleMismatchException(member.role.toString())
 
             Output(
                 isRegistered = true,

--- a/src/main/kotlin/com/dobby/backend/application/usecase/auth/FetchNaverUserInfoUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/auth/FetchNaverUserInfoUseCase.kt
@@ -1,6 +1,7 @@
 package com.dobby.backend.application.usecase.auth
 
 import com.dobby.backend.application.usecase.UseCase
+import com.dobby.backend.domain.exception.SignInRoleMismatchException
 import com.dobby.backend.domain.gateway.member.MemberGateway
 import com.dobby.backend.domain.gateway.auth.NaverAuthGateway
 import com.dobby.backend.domain.gateway.auth.TokenGateway
@@ -16,7 +17,8 @@ class FetchNaverUserInfoUseCase(
 
     data class Input(
         val authorizationCode: String,
-        val state: String
+        val state: String,
+        val role: RoleType
     )
 
     data class Output(
@@ -39,6 +41,9 @@ class FetchNaverUserInfoUseCase(
         return if (member != null) {
             val jwtAccessToken = jwtTokenGateway.generateAccessToken(member)
             val jwtRefreshToken = jwtTokenGateway.generateRefreshToken(member)
+
+            if(member.role != input.role)
+                throw SignInRoleMismatchException(member.role.toString())
 
             Output(
                 isRegistered = true,

--- a/src/main/kotlin/com/dobby/backend/domain/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/exception/ErrorCode.kt
@@ -55,7 +55,7 @@ enum class ErrorCode(
      * Signin error codes
      */
     SIGNIN_MEMBER_NOT_FOUND("SIGN_IN_001", "Member Not Found. Please signup. (Redirect URI must be /v1/auth/{role}/signup)", HttpStatus.NOT_FOUND),
-    SIGNIN_ROLE_MISMATCH("SIGN_IN_002", "Already registered member as %s. Please login as %s", HttpStatus.BAD_REQUEST),
+    SIGNIN_ROLE_MISMATCH("SIGN_IN_002", "Already registered as another role.", HttpStatus.BAD_REQUEST),
 
     /**
      * Email Verification error codes
@@ -89,5 +89,9 @@ enum class ErrorCode(
     EXPERIMENT_POST_IMAGE_SIZE_LIMIT("EP005", "Image can be uploaded maximum 3 images.", HttpStatus.BAD_REQUEST),
     EXPERIMENT_POST_RECRUIT_STATUS_ERROR("EP006", "This experiment post has already closed recruitment.", HttpStatus.BAD_REQUEST),
     EXPERIMENT_POST_CANNOT_UPDATE_DATE("EP007", "You cannot update experiment post with past experiment dates.", HttpStatus.BAD_REQUEST),
-    EXPERIMENT_POST_INVALID_ONLINE_REQUEST("EP008", "univName, region, area field value must be null when MatchType is online.", HttpStatus.BAD_REQUEST),
+    EXPERIMENT_POST_INVALID_ONLINE_REQUEST("EP008", "univName, region, area field value must be null when MatchType is online.", HttpStatus.BAD_REQUEST);
+
+    fun formatMessage(vararg args: Any): String {
+        return String.format(message, *args)
+    }
 }

--- a/src/main/kotlin/com/dobby/backend/domain/exception/SignInRoleMismatchException.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/exception/SignInRoleMismatchException.kt
@@ -1,0 +1,10 @@
+package com.dobby.backend.domain.exception
+
+class SignInRoleMismatchException(
+    existingRole: String,
+) : DomainException(
+    errorCode = ErrorCode.SIGNIN_ROLE_MISMATCH,
+    data = mapOf(
+        "existingRole" to existingRole
+    )
+)

--- a/src/main/kotlin/com/dobby/backend/presentation/api/controller/AuthController.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/controller/AuthController.kt
@@ -25,7 +25,7 @@ class AuthController(
         @RequestParam role : RoleType,
         @RequestBody @Valid request: GoogleOauthLoginRequest
     ): OauthLoginResponse {
-        val input = AuthMapper.toGoogleOauthLoginInput(request)
+        val input = AuthMapper.toGoogleOauthLoginInput(request, role)
         val output = authService.getGoogleUserInfo(input)
         return AuthMapper.toGoogleOauthLoginResponse(output)
     }

--- a/src/main/kotlin/com/dobby/backend/presentation/api/controller/AuthController.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/controller/AuthController.kt
@@ -36,7 +36,7 @@ class AuthController(
         @RequestParam role : RoleType,
         @RequestBody @Valid request: NaverOauthLoginRequest
     ): OauthLoginResponse {
-        val input = AuthMapper.toNaverOauthLoginInput(request)
+        val input = AuthMapper.toNaverOauthLoginInput(request, role)
         val output = authService.getNaverUserInfo(input)
         return AuthMapper.toNaverOauthLoginResponse(output)
     }

--- a/src/main/kotlin/com/dobby/backend/presentation/api/mapper/AuthMapper.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/mapper/AuthMapper.kt
@@ -4,6 +4,7 @@ import com.dobby.backend.application.usecase.auth.FetchGoogleUserInfoUseCase
 import com.dobby.backend.application.usecase.auth.FetchNaverUserInfoUseCase
 import com.dobby.backend.application.usecase.auth.GenerateTestTokenUseCase
 import com.dobby.backend.application.usecase.auth.GenerateTokenWithRefreshTokenUseCase
+import com.dobby.backend.infrastructure.database.entity.enums.RoleType
 import com.dobby.backend.presentation.api.dto.response.auth.OauthLoginResponse
 import com.dobby.backend.presentation.api.dto.response.auth.TestMemberSignInResponse
 import com.dobby.backend.presentation.api.dto.response.member.MemberResponse
@@ -12,9 +13,10 @@ import com.dobby.backend.presentation.api.dto.request.auth.MemberRefreshTokenReq
 import com.dobby.backend.presentation.api.dto.request.auth.NaverOauthLoginRequest
 
 object AuthMapper {
-    fun toGoogleOauthLoginInput(request: GoogleOauthLoginRequest): FetchGoogleUserInfoUseCase.Input {
+    fun toGoogleOauthLoginInput(request: GoogleOauthLoginRequest, role: RoleType): FetchGoogleUserInfoUseCase.Input {
         return FetchGoogleUserInfoUseCase.Input(
-            authorizationCode = request.authorizationCode
+            authorizationCode = request.authorizationCode,
+            role = role
         )
     }
 

--- a/src/main/kotlin/com/dobby/backend/presentation/api/mapper/AuthMapper.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/mapper/AuthMapper.kt
@@ -35,10 +35,12 @@ object AuthMapper {
         )
     }
 
-    fun toNaverOauthLoginInput(request: NaverOauthLoginRequest): FetchNaverUserInfoUseCase.Input {
+    fun toNaverOauthLoginInput(request: NaverOauthLoginRequest, role: RoleType
+    ): FetchNaverUserInfoUseCase.Input {
         return FetchNaverUserInfoUseCase.Input(
             authorizationCode = request.authorizationCode,
-            state = request.state
+            state = request.state,
+            role = role
         )
     }
 

--- a/src/test/kotlin/com/dobby/backend/application/usecase/auth/FetchGoogleUserInfoUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/auth/FetchGoogleUserInfoUseCaseTest.kt
@@ -28,7 +28,7 @@ class FetchGoogleUserInfoUseCaseTest : BehaviorSpec({
     )
 
     given("Google OAuth 요청이 들어왔을 때") {
-        val input = FetchGoogleUserInfoUseCase.Input(authorizationCode = "valid-auth-code")
+        val input = FetchGoogleUserInfoUseCase.Input(authorizationCode = "valid-auth-code", role = RoleType.PARTICIPANT)
         val mockMember = Member(
             id = 1L,
             oauthEmail = "test@example.com",

--- a/src/test/kotlin/com/dobby/backend/application/usecase/auth/FetchNaverUserInfoUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/auth/FetchNaverUserInfoUseCaseTest.kt
@@ -29,7 +29,7 @@ class FetchNaverUserInfoUseCaseTest : BehaviorSpec({
     )
 
     given("Naver OAuth 요청이 들어왔을 때") {
-        val input = FetchNaverUserInfoUseCase.Input(authorizationCode = "valid-auth-code", state = "valid-state")
+        val input = FetchNaverUserInfoUseCase.Input(authorizationCode = "valid-auth-code", state = "valid-state", role = RoleType.PARTICIPANT)
         val mockMember = Member(
             id = 1L,
             oauthEmail = "test@example.com",


### PR DESCRIPTION
## 💡 작업 내용
- 구글/네이버 로그인 시 유저가 **이미 다른 Role로 등록되어있다면, 로그인 시도 시 알맞은 에러 메시지를 반환**합니다.

### case 1) Google 로그인 시도 시 예외처리 
<img src="https://github.com/user-attachments/assets/9967f0bf-fd7e-4bd2-8575-3f297b934e2f" width="500">
<img src="https://github.com/user-attachments/assets/e2d6b559-24b8-4dd6-9a4f-b3b41622a228" width="500">

### case 2) Naver 로그인 시도 시 예외처리
<img src="https://github.com/user-attachments/assets/7963937b-957d-4a2f-b121-30e325920f9d" width="500">
<img src="https://github.com/user-attachments/assets/ddc8db3a-9a78-4e28-928b-05889c186164" width="500">

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- 관련된 Discussion 등이 있다면 첨부해주세요


## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-223

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 로그인 프로세스에 역할(Role) 검증 기능 추가
	- OAuth 로그인 시 사용자 역할 일치 여부 확인 메커니즘 도입

- **버그 수정**
	- 잘못된 역할로 로그인 시도하는 경우 예외 처리 개선
	- 역할 불일치에 대한 명확한 오류 메시지 제공

- **기타 변경**
	- 에러 코드 및 예외 처리 로직 업데이트
	- OAuth 로그인 컨트롤러 및 매퍼 로직 확장
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-223