### PR TITLE
[YS-178] feat: 연구자/참여자 회원 정보 수정

### DIFF
--- a/src/main/kotlin/com/dobby/backend/application/service/MemberService.kt
+++ b/src/main/kotlin/com/dobby/backend/application/service/MemberService.kt
@@ -15,7 +15,8 @@ class MemberService(
     private val verifyResearcherEmailUseCase: VerifyResearcherEmailUseCase,
     private val getResearcherInfoUseCase: GetResearcherInfoUseCase,
     private val getParticipantInfoUseCase: GetParticipantInfoUseCase,
-    private val updateResearcherInfoUseCase: UpdateResearcherInfoUseCase
+    private val updateResearcherInfoUseCase: UpdateResearcherInfoUseCase,
+    private val updateParticipantInfoUseCase: UpdateParticipantInfoUseCase
 ) {
     @Transactional
     fun participantSignup(input: CreateParticipantUseCase.Input): CreateParticipantUseCase.Output {
@@ -44,5 +45,10 @@ class MemberService(
     @Transactional
     fun updateResearcherInfo(input: UpdateResearcherInfoUseCase.Input): UpdateResearcherInfoUseCase.Output {
         return updateResearcherInfoUseCase.execute(input)
+    }
+
+    @Transactional
+    fun updateParticipantInfo(input: UpdateParticipantInfoUseCase.Input): UpdateParticipantInfoUseCase.Output {
+        return updateParticipantInfoUseCase.execute(input)
     }
 }

--- a/src/main/kotlin/com/dobby/backend/application/service/MemberService.kt
+++ b/src/main/kotlin/com/dobby/backend/application/service/MemberService.kt
@@ -15,6 +15,7 @@ class MemberService(
     private val verifyResearcherEmailUseCase: VerifyResearcherEmailUseCase,
     private val getResearcherInfoUseCase: GetResearcherInfoUseCase,
     private val getParticipantInfoUseCase: GetParticipantInfoUseCase,
+    private val updateResearcherInfoUseCase: UpdateResearcherInfoUseCase
 ) {
     @Transactional
     fun participantSignup(input: CreateParticipantUseCase.Input): CreateParticipantUseCase.Output {
@@ -24,7 +25,7 @@ class MemberService(
     @Transactional
     fun researcherSignup(input: CreateResearcherUseCase.Input) : CreateResearcherUseCase.Output{
         val existingMember = memberGateway.findByOauthEmailAndStatus(input.oauthEmail, MemberStatus.ACTIVE)
-        if(existingMember!= null) throw SignupOauthEmailDuplicateException
+        if (existingMember!= null) throw SignupOauthEmailDuplicateException
 
         verifyResearcherEmailUseCase.execute(input.univEmail)
         return createResearcherUseCase.execute(input)
@@ -38,5 +39,10 @@ class MemberService(
     @Transactional
     fun getParticipantInfo(input: GetParticipantInfoUseCase.Input): GetParticipantInfoUseCase.Output {
         return getParticipantInfoUseCase.execute(input)
+    }
+
+    @Transactional
+    fun updateResearcherInfo(input: UpdateResearcherInfoUseCase.Input): UpdateResearcherInfoUseCase.Output {
+        return updateResearcherInfoUseCase.execute(input)
     }
 }

--- a/src/main/kotlin/com/dobby/backend/application/usecase/member/UpdateParticipantInfoUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/member/UpdateParticipantInfoUseCase.kt
@@ -1,0 +1,62 @@
+package com.dobby.backend.application.usecase.member
+
+import com.dobby.backend.application.usecase.UseCase
+import com.dobby.backend.domain.exception.ParticipantNotFoundException
+import com.dobby.backend.domain.gateway.member.ParticipantGateway
+import com.dobby.backend.domain.model.member.Member
+import com.dobby.backend.domain.model.member.Participant
+import com.dobby.backend.infrastructure.database.entity.enums.GenderType
+import com.dobby.backend.infrastructure.database.entity.enums.MatchType
+import java.time.LocalDate
+
+class UpdateParticipantInfoUseCase(
+    private val participantGateway: ParticipantGateway
+) : UseCase<UpdateParticipantInfoUseCase.Input, UpdateParticipantInfoUseCase.Output> {
+
+    data class Input(
+        val memberId: String,
+        val contactEmail: String,
+        val name: String,
+        val basicAddressInfo: Participant.AddressInfo,
+        val additionalAddressInfo: Participant.AddressInfo?,
+        val matchType: MatchType?
+    )
+
+    data class Output(
+        val member: Member,
+        val gender: GenderType,
+        val birthDate: LocalDate,
+        val basicAddressInfo: Participant.AddressInfo,
+        val additionalAddressInfo: Participant.AddressInfo?,
+        val matchType: MatchType?
+    )
+
+    override fun execute(input: Input): Output {
+        val participant = participantGateway.findByMemberId(input.memberId)
+            ?: throw ParticipantNotFoundException
+
+        val updatedParticipant = participantGateway.save(
+            participant.updateInfo(
+                contactEmail = input.contactEmail,
+                name = input.name,
+                basicAddressInfo = Participant.AddressInfo(
+                    region = input.basicAddressInfo.region,
+                    area = input.basicAddressInfo.area
+                ),
+                additionalAddressInfo = input.additionalAddressInfo?.let {
+                    Participant.AddressInfo(region = it.region, area = it.area)
+                },
+                matchType = input.matchType
+            )
+        )
+
+        return Output(
+            member = updatedParticipant.member,
+            gender = updatedParticipant.gender,
+            birthDate = updatedParticipant.birthDate,
+            basicAddressInfo = updatedParticipant.basicAddressInfo,
+            additionalAddressInfo = updatedParticipant.additionalAddressInfo,
+            matchType = updatedParticipant.matchType
+        )
+    }
+}

--- a/src/main/kotlin/com/dobby/backend/application/usecase/member/UpdateResearcherInfoUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/member/UpdateResearcherInfoUseCase.kt
@@ -1,0 +1,50 @@
+package com.dobby.backend.application.usecase.member
+
+import com.dobby.backend.application.usecase.UseCase
+import com.dobby.backend.domain.exception.ResearcherNotFoundException
+import com.dobby.backend.domain.gateway.member.ResearcherGateway
+import com.dobby.backend.domain.model.member.Member
+
+class UpdateResearcherInfoUseCase(
+    private val researcherGateway: ResearcherGateway
+) : UseCase<UpdateResearcherInfoUseCase.Input, UpdateResearcherInfoUseCase.Output> {
+    data class Input(
+        val memberId: String,
+        val contactEmail: String,
+        val name: String,
+        val univName: String,
+        val major: String,
+        val labInfo: String?
+    )
+
+    data class Output(
+        val member : Member,
+        val univEmail: String,
+        val univName: String,
+        val major: String,
+        val labInfo: String?
+    )
+
+    override fun execute(input: Input): Output {
+        val researcher = researcherGateway.findByMemberId(input.memberId)
+            ?: throw ResearcherNotFoundException
+
+        val updatedResearcher = researcherGateway.save(
+            researcher.updateInfo(
+                contactEmail = input.contactEmail,
+                name = input.name,
+                univName = input.univName,
+                major = input.major,
+                labInfo = input.labInfo
+            )
+        )
+
+        return Output(
+            member = updatedResearcher.member,
+            univEmail = updatedResearcher.univEmail,
+            univName = updatedResearcher.univName,
+            major = updatedResearcher.major,
+            labInfo = updatedResearcher.labInfo
+        )
+    }
+}

--- a/src/main/kotlin/com/dobby/backend/domain/model/member/Participant.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/model/member/Participant.kt
@@ -5,6 +5,7 @@ import com.dobby.backend.infrastructure.database.entity.enums.MatchType
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Area
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 data class Participant(
     val id: String,
@@ -51,7 +52,8 @@ data class Participant(
         return this.copy(
             member = member.copy(
                 contactEmail = contactEmail,
-                name = name
+                name = name,
+                updatedAt = LocalDateTime.now()
             ),
             basicAddressInfo = basicAddressInfo,
             additionalAddressInfo = additionalAddressInfo?.copy() ?: AddressInfo(

--- a/src/main/kotlin/com/dobby/backend/domain/model/member/Participant.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/model/member/Participant.kt
@@ -40,5 +40,25 @@ data class Participant(
             matchType = matchType
         )
     }
-}
 
+    fun updateInfo(
+        contactEmail: String,
+        name: String,
+        basicAddressInfo: AddressInfo,
+        additionalAddressInfo: AddressInfo?,
+        matchType: MatchType?
+    ): Participant {
+        return this.copy(
+            member = member.copy(
+                contactEmail = contactEmail,
+                name = name
+            ),
+            basicAddressInfo = basicAddressInfo,
+            additionalAddressInfo = additionalAddressInfo?.copy() ?: AddressInfo(
+                region = Region.NONE,
+                area = Area.NONE
+            ),
+            matchType = matchType
+        )
+    }
+}

--- a/src/main/kotlin/com/dobby/backend/domain/model/member/Researcher.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/model/member/Researcher.kt
@@ -1,5 +1,7 @@
 package com.dobby.backend.domain.model.member
 
+import java.time.LocalDateTime
+
 data class Researcher(
     val id: String,
     var member: Member,
@@ -40,7 +42,8 @@ data class Researcher(
         return this.copy(
             member = member.copy(
                 contactEmail = contactEmail,
-                name = name
+                name = name,
+                updatedAt = LocalDateTime.now()
             ),
             univName = univName,
             major = major,

--- a/src/main/kotlin/com/dobby/backend/domain/model/member/Researcher.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/model/member/Researcher.kt
@@ -29,4 +29,22 @@ data class Researcher(
             labInfo = labInfo
         )
     }
+
+    fun updateInfo(
+        contactEmail: String,
+        name: String,
+        univName: String,
+        major: String,
+        labInfo: String?
+    ): Researcher {
+        return this.copy(
+            member = member.copy(
+                contactEmail = contactEmail,
+                name = name
+            ),
+            univName = univName,
+            major = major,
+            labInfo = labInfo
+        )
+    }
 }

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/member/ParticipantEntity.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/member/ParticipantEntity.kt
@@ -35,8 +35,8 @@ class ParticipantEntity (
 
     @Embedded
     @AttributeOverrides(
-        AttributeOverride(name = "region", column = Column(name = "optional_region", nullable = false)),
-        AttributeOverride(name = "area", column = Column(name = "optional_area", nullable = false))
+        AttributeOverride(name = "region", column = Column(name = "additional_region", nullable = false)),
+        AttributeOverride(name = "area", column = Column(name = "additional_area", nullable = false))
     )
     val additionalAddressInfo: AddressInfo,
 

--- a/src/main/kotlin/com/dobby/backend/infrastructure/gateway/member/ResearcherGatewayImpl.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/gateway/member/ResearcherGatewayImpl.kt
@@ -22,5 +22,4 @@ class ResearcherGatewayImpl(
             .save(ResearcherEntity.fromDomain(researcher))
         return savedEntity.toDomain()
     }
-
 }

--- a/src/main/kotlin/com/dobby/backend/presentation/api/controller/MemberController.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/controller/MemberController.kt
@@ -3,6 +3,7 @@ package com.dobby.backend.presentation.api.controller
 import com.dobby.backend.application.service.MemberService
 import com.dobby.backend.presentation.api.dto.request.member.ParticipantSignupRequest
 import com.dobby.backend.presentation.api.dto.request.member.ResearcherSignupRequest
+import com.dobby.backend.presentation.api.dto.request.member.UpdateParticipantInfoRequest
 import com.dobby.backend.presentation.api.dto.request.member.UpdateResearcherInfoRequest
 import com.dobby.backend.presentation.api.dto.response.member.ParticipantInfoResponse
 import com.dobby.backend.presentation.api.dto.response.member.ResearcherInfoResponse
@@ -84,6 +85,20 @@ class MemberController(
     fun getParticipantInfo(): ParticipantInfoResponse {
         val input = MemberMapper.toGetParticipantInfoUseCaseInput()
         val output = memberService.getParticipantInfo(input)
+        return MemberMapper.toParticipantInfoResponse(output)
+    }
+
+    @PreAuthorize("hasRole('PARTICIPANT')")
+    @PutMapping("/participants/me")
+    @Operation(
+        summary = "참여자 회원 정보 수정",
+        description = "참여자의 회원 정보를 수정합니다."
+    )
+    fun updateParticipantInfo(
+        @RequestBody @Valid request: UpdateParticipantInfoRequest
+    ): ParticipantInfoResponse {
+        val input = MemberMapper.toUpdateParticipantInfoUseCaseInput(request)
+        val output = memberService.updateParticipantInfo(input)
         return MemberMapper.toParticipantInfoResponse(output)
     }
 }

--- a/src/main/kotlin/com/dobby/backend/presentation/api/controller/MemberController.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/controller/MemberController.kt
@@ -3,6 +3,7 @@ package com.dobby.backend.presentation.api.controller
 import com.dobby.backend.application.service.MemberService
 import com.dobby.backend.presentation.api.dto.request.member.ParticipantSignupRequest
 import com.dobby.backend.presentation.api.dto.request.member.ResearcherSignupRequest
+import com.dobby.backend.presentation.api.dto.request.member.UpdateResearcherInfoRequest
 import com.dobby.backend.presentation.api.dto.response.member.ParticipantInfoResponse
 import com.dobby.backend.presentation.api.dto.response.member.ResearcherInfoResponse
 import com.dobby.backend.presentation.api.dto.response.member.SignupResponse
@@ -51,8 +52,8 @@ class MemberController(
     @PreAuthorize("hasRole('RESEARCHER')")
     @GetMapping("/researchers/me")
     @Operation(
-        summary = "연구자 기본 정보 렌더링",
-        description = "연구자의 기본 정보 [학교 + 전공 + 랩실 정보 + 이름]를 반환합니다."
+        summary = "연구자 회원 정보 렌더링",
+        description = "연구자의 회원 정보를 반환합니다."
     )
     fun getResearcherInfo(): ResearcherInfoResponse {
         val input = MemberMapper.toGetResearcherInfoUseCaseInput()
@@ -60,11 +61,25 @@ class MemberController(
         return MemberMapper.toResearcherInfoResponse(output)
     }
 
+    @PreAuthorize("hasRole('RESEARCHER')")
+    @PutMapping("/researchers/me")
+    @Operation(
+        summary = "연구자 회원 정보 수정",
+        description = "연구자의 회원 정보를 수정합니다."
+    )
+    fun updateResearcherInfo(
+        @RequestBody @Valid request: UpdateResearcherInfoRequest
+    ): ResearcherInfoResponse {
+        val input = MemberMapper.toUpdateResearcherInfoUseCaseInput(request)
+        val output = memberService.updateResearcherInfo(input)
+        return MemberMapper.toResearcherInfoResponse(output)
+    }
+
     @PreAuthorize("hasRole('PARTICIPANT')")
     @GetMapping("/participants/me")
     @Operation(
-        summary = "참여자 회원 기본 정보 렌더링",
-        description = "참여자의 기본 정보를 반환합니다."
+        summary = "참여자 회원 정보 렌더링",
+        description = "참여자의 회원 정보를 반환합니다."
     )
     fun getParticipantInfo(): ParticipantInfoResponse {
         val input = MemberMapper.toGetParticipantInfoUseCaseInput()

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/member/UpdateParticipantInfoRequest.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/member/UpdateParticipantInfoRequest.kt
@@ -18,11 +18,11 @@ data class UpdateParticipantInfoRequest(
 
     @NotBlank(message = "거주 지역은 공백일 수 없습니다.")
     @Schema(description = "기본 주소 정보")
-    var basicAddressInfo: AddressInfoResponse,
+    val basicAddressInfo: AddressInfoResponse,
 
     @Schema(description = "추가 주소 정보")
-    var additionalAddressInfo: AddressInfoResponse?,
+    val additionalAddressInfo: AddressInfoResponse?,
 
     @Schema(description = "선호 실험 진행 방식")
-    var matchType: MatchType?,
+    val matchType: MatchType?,
 )

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/member/UpdateParticipantInfoRequest.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/member/UpdateParticipantInfoRequest.kt
@@ -1,0 +1,28 @@
+package com.dobby.backend.presentation.api.dto.request.member
+
+import com.dobby.backend.infrastructure.database.entity.enums.MatchType
+import com.dobby.backend.presentation.api.dto.response.member.AddressInfoResponse
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+
+data class UpdateParticipantInfoRequest(
+    @Email(message= "연락 받을 이메일이 유효하지 않습니다.")
+    @NotBlank(message = "연락 받을 이메일은 공백일 수 없습니다.")
+    @Schema(description = "연락 받을 이메일")
+    val contactEmail: String,
+
+    @NotBlank(message = "이름은 공백일 수 없습니다.")
+    @Schema(description = "이름")
+    val name : String,
+
+    @NotBlank(message = "거주 지역은 공백일 수 없습니다.")
+    @Schema(description = "기본 주소 정보")
+    var basicAddressInfo: AddressInfoResponse,
+
+    @Schema(description = "추가 주소 정보")
+    var additionalAddressInfo: AddressInfoResponse?,
+
+    @Schema(description = "선호 실험 진행 방식")
+    var matchType: MatchType?,
+)

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/member/UpdateResearcherInfoRequest.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/member/UpdateResearcherInfoRequest.kt
@@ -1,0 +1,28 @@
+package com.dobby.backend.presentation.api.dto.request.member
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+
+data class UpdateResearcherInfoRequest(
+
+    @Email(message= "연락 받을 이메일이 유효하지 않습니다.")
+    @NotBlank(message = "연락 받을 이메일은 공백일 수 없습니다.")
+    @Schema(description = "연락 받을 이메일")
+    val contactEmail: String,
+
+    @NotBlank(message = "이름은 공백일 수 없습니다.")
+    @Schema(description = "이름")
+    val name: String,
+
+    @NotBlank(message = "학교명은 공백일 수 없습니다.")
+    @Schema(description = "학교명")
+    val univName: String,
+
+    @NotBlank(message = "전공명은 공백일 수 없습니다.")
+    @Schema(description = "전공명")
+    val major: String,
+
+    @Schema(description = "연구실 정보")
+    val labInfo: String?
+)

--- a/src/main/kotlin/com/dobby/backend/presentation/api/mapper/MemberMapper.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/mapper/MemberMapper.kt
@@ -1,10 +1,12 @@
 package com.dobby.backend.presentation.api.mapper
 
 import com.dobby.backend.application.usecase.member.*
+import com.dobby.backend.domain.model.member.Participant
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Area
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region
 import com.dobby.backend.presentation.api.dto.request.member.ParticipantSignupRequest
 import com.dobby.backend.presentation.api.dto.request.member.ResearcherSignupRequest
+import com.dobby.backend.presentation.api.dto.request.member.UpdateParticipantInfoRequest
 import com.dobby.backend.presentation.api.dto.request.member.UpdateResearcherInfoRequest
 import com.dobby.backend.presentation.api.dto.response.member.*
 import com.dobby.backend.util.getCurrentMemberId
@@ -134,6 +136,34 @@ object MemberMapper {
             univName = response.univName,
             major = response.major,
             labInfo = response.labInfo,
+        )
+    }
+
+    fun toUpdateParticipantInfoUseCaseInput(request: UpdateParticipantInfoRequest): UpdateParticipantInfoUseCase.Input {
+        return UpdateParticipantInfoUseCase.Input(
+            memberId = getCurrentMemberId(),
+            contactEmail = request.contactEmail,
+            name = request.name,
+            basicAddressInfo = Participant.AddressInfo(
+                region = request.basicAddressInfo.region,
+                area = request.basicAddressInfo.area
+            ),
+            additionalAddressInfo = Participant.AddressInfo(
+                region = request.additionalAddressInfo?.region ?: Region.NONE,
+                area = request.additionalAddressInfo?.area ?: Area.NONE
+            ),
+            matchType = request.matchType
+        )
+    }
+
+    fun toParticipantInfoResponse(output: UpdateParticipantInfoUseCase.Output): ParticipantInfoResponse {
+        return ParticipantInfoResponse(
+            memberInfo = MemberResponse.fromDomain(output.member),
+            gender = output.gender,
+            birthDate = output.birthDate,
+            basicAddressInfo = AddressInfoResponse.fromDomain(output.basicAddressInfo),
+            additionalAddressInfo = output.additionalAddressInfo?.let { AddressInfoResponse.fromDomain(it) },
+            matchType = output.matchType
         )
     }
 }

--- a/src/main/kotlin/com/dobby/backend/presentation/api/mapper/MemberMapper.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/mapper/MemberMapper.kt
@@ -1,13 +1,11 @@
 package com.dobby.backend.presentation.api.mapper
 
-import com.dobby.backend.application.usecase.member.GetResearcherInfoUseCase
-import com.dobby.backend.application.usecase.member.CreateResearcherUseCase
-import com.dobby.backend.application.usecase.member.CreateParticipantUseCase
-import com.dobby.backend.application.usecase.member.GetParticipantInfoUseCase
+import com.dobby.backend.application.usecase.member.*
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Area
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region
 import com.dobby.backend.presentation.api.dto.request.member.ParticipantSignupRequest
 import com.dobby.backend.presentation.api.dto.request.member.ResearcherSignupRequest
+import com.dobby.backend.presentation.api.dto.request.member.UpdateResearcherInfoRequest
 import com.dobby.backend.presentation.api.dto.response.member.*
 import com.dobby.backend.util.getCurrentMemberId
 
@@ -115,6 +113,27 @@ object MemberMapper {
             basicAddressInfo = AddressInfoResponse.fromDomain(output.basicAddressInfo),
             additionalAddressInfo = output.additionalAddressInfo?.let { AddressInfoResponse.fromDomain(it) },
             matchType = output.matchType
+        )
+    }
+
+    fun toUpdateResearcherInfoUseCaseInput(request: UpdateResearcherInfoRequest): UpdateResearcherInfoUseCase.Input {
+        return UpdateResearcherInfoUseCase.Input(
+            memberId = getCurrentMemberId(),
+            contactEmail = request.contactEmail,
+            name = request.name,
+            univName = request.univName,
+            major = request.major,
+            labInfo = request.labInfo
+        )
+    }
+
+    fun toResearcherInfoResponse(response: UpdateResearcherInfoUseCase.Output): ResearcherInfoResponse {
+        return ResearcherInfoResponse(
+            memberInfo = MemberResponse.fromDomain(response.member),
+            univEmail = response.univEmail,
+            univName = response.univName,
+            major = response.major,
+            labInfo = response.labInfo,
         )
     }
 }

--- a/src/test/kotlin/com/dobby/backend/application/usecase/member/UpdateParticipantInfoUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/member/UpdateParticipantInfoUseCaseTest.kt
@@ -1,0 +1,92 @@
+package com.dobby.backend.application.usecase.member
+
+import com.dobby.backend.domain.exception.ParticipantNotFoundException
+import com.dobby.backend.domain.gateway.member.ParticipantGateway
+import com.dobby.backend.domain.model.member.Member
+import com.dobby.backend.domain.model.member.Participant
+import com.dobby.backend.infrastructure.database.entity.enums.*
+import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Area
+import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.assertions.throwables.shouldThrow
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class UpdateParticipantInfoUseCaseTest : BehaviorSpec({
+    val participantGateway = mockk<ParticipantGateway>()
+    val useCase = UpdateParticipantInfoUseCase(participantGateway)
+
+    given("유효한 memberId가 주어졌을 때") {
+        val memberId = "1"
+
+        val participant = Participant(
+            id = memberId,
+            member = Member(id = memberId, name = "기존 이름", contactEmail = "old@example.com", oauthEmail = "oauth@example.com",
+                provider = ProviderType.NAVER, role = RoleType.PARTICIPANT, status = MemberStatus.ACTIVE,
+                createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now()),
+            gender = GenderType.MALE,
+            birthDate = LocalDate.of(1998, 5, 10),
+            basicAddressInfo = Participant.AddressInfo(Region.SEOUL, Area.SEOUL_ALL),
+            additionalAddressInfo = Participant.AddressInfo(Region.INCHEON, Area.SEOGU),
+            matchType = MatchType.OFFLINE
+        )
+
+        val input = UpdateParticipantInfoUseCase.Input(
+            memberId = memberId,
+            contactEmail = "new@example.com",
+            name = "새로운 이름",
+            basicAddressInfo = Participant.AddressInfo(Region.BUSAN, Area.BUSAN_ALL),
+            additionalAddressInfo = Participant.AddressInfo(Region.DAEGU, Area.DAEGU_ALL),
+            matchType = MatchType.ONLINE
+        )
+
+        every { participantGateway.findByMemberId(memberId) } returns participant
+        every { participantGateway.save(any()) } answers { firstArg() }
+
+        `when`("useCase의 execute가 호출되면") {
+            val result = useCase.execute(input)
+
+            then("정상적으로 participant 정보가 업데이트된다") {
+                result.member.id shouldBe memberId
+                result.member.contactEmail shouldBe input.contactEmail
+                result.member.name shouldBe input.name
+                result.basicAddressInfo.region shouldBe input.basicAddressInfo.region
+                result.basicAddressInfo.area shouldBe input.basicAddressInfo.area
+                result.additionalAddressInfo?.region shouldBe input.additionalAddressInfo?.region
+                result.additionalAddressInfo?.area shouldBe input.additionalAddressInfo?.area
+                result.matchType shouldBe input.matchType
+            }
+
+            then("Gateway를 통해 save가 호출된다") {
+                verify { participantGateway.save(any()) }
+            }
+        }
+    }
+
+    given("존재하지 않는 participantId가 주어졌을 때") {
+        val memberId = "1"
+
+        every { participantGateway.findByMemberId(memberId) } returns null
+
+        `when`("useCase의 execute가 호출되면") {
+            val input = UpdateParticipantInfoUseCase.Input(
+                memberId = memberId,
+                contactEmail = "test@example.com",
+                name = "테스트",
+                basicAddressInfo = Participant.AddressInfo(Region.SEOUL, Area.SEOUL_ALL),
+                additionalAddressInfo = null,
+                matchType = null
+            )
+
+            then("ParticipantNotFoundException이 발생한다") {
+                shouldThrow<ParticipantNotFoundException> {
+                    useCase.execute(input)
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/dobby/backend/application/usecase/member/UpdateResearcherInfoUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/member/UpdateResearcherInfoUseCaseTest.kt
@@ -1,0 +1,91 @@
+package com.dobby.backend.application.usecase.member
+
+import com.dobby.backend.domain.exception.ResearcherNotFoundException
+import com.dobby.backend.domain.gateway.member.ResearcherGateway
+import com.dobby.backend.domain.model.member.Member
+import com.dobby.backend.domain.model.member.Researcher
+import com.dobby.backend.infrastructure.database.entity.enums.MemberStatus
+import com.dobby.backend.infrastructure.database.entity.enums.ProviderType
+import com.dobby.backend.infrastructure.database.entity.enums.RoleType
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.assertions.throwables.shouldThrow
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.time.LocalDateTime
+
+class UpdateResearcherInfoUseCaseTest : BehaviorSpec({
+    val researcherGateway = mockk<ResearcherGateway>()
+    val useCase = UpdateResearcherInfoUseCase(researcherGateway)
+
+    given("유효한 memberId가 주어졌을 때") {
+        val memberId = "1"
+
+        val researcher = Researcher(
+            id = memberId,
+            member = Member(
+                id = memberId, name = "기존 연구자", contactEmail = "old@example.com",
+                oauthEmail = "oauth@example.com", provider = ProviderType.NAVER, role = RoleType.RESEARCHER,
+                status = MemberStatus.ACTIVE, createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now()
+            ),
+            univEmail = "old@university.com",
+            univName = "Old University",
+            major = "Old Major",
+            labInfo = "Old Lab",
+            emailVerified = true
+        )
+
+        val input = UpdateResearcherInfoUseCase.Input(
+            memberId = memberId,
+            contactEmail = "new@example.com",
+            name = "새 연구자",
+            univName = "New University",
+            major = "New Major",
+            labInfo = "New Lab"
+        )
+
+        every { researcherGateway.findByMemberId(memberId) } returns researcher
+        every { researcherGateway.save(any()) } answers { firstArg() }
+
+        `when`("useCase의 execute가 호출되면") {
+            val result = useCase.execute(input)
+
+            then("정상적으로 researcher 정보가 업데이트된다") {
+                result.member.id shouldBe memberId
+                result.member.contactEmail shouldBe input.contactEmail
+                result.member.name shouldBe input.name
+                result.univName shouldBe input.univName
+                result.major shouldBe input.major
+                result.labInfo shouldBe input.labInfo
+            }
+
+            then("Gateway를 통해 save가 호출된다") {
+                verify { researcherGateway.save(any()) }
+            }
+        }
+    }
+
+    given("존재하지 않는 researcherId가 주어졌을 때") {
+        val memberId = "1"
+
+        every { researcherGateway.findByMemberId(memberId) } returns null
+
+        `when`("useCase의 execute가 호출되면") {
+            val input = UpdateResearcherInfoUseCase.Input(
+                memberId = memberId,
+                contactEmail = "test@example.com",
+                name = "테스트",
+                univName = "University",
+                major = "Major",
+                labInfo = null
+            )
+
+            then("ResearcherNotFoundException이 발생한다") {
+                shouldThrow<ResearcherNotFoundException> {
+                    useCase.execute(input)
+                }
+            }
+        }
+    }
+})


### PR DESCRIPTION
## 💡 작업 내용
- 연구자 회원 정보 수정 API 구현
  - 소셜 로그인 아이디, 학교 인증 메일 제외 수정 가능
  <img width="300" alt="연구자 회원정보 수정" src="https://github.com/user-attachments/assets/2a9c844f-3f47-4bd0-97f9-ac77694c50d4" />

- 참여자 회원 정보 수정 API 구현
  - 소셜 로그인 아이디, 생년월일, 성별 제외 수정 가능
  <img width="300" alt="참여자 회원정보 수정" src="https://github.com/user-attachments/assets/1d774a56-6cc6-4d72-b8c8-d2090e583f20" />

- 관련 테스트 코드 작성

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- 리뷰만 부탁드립니다~ 코멘트도 확인 부탁드려요!


## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-178

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 연구자와 참가자 정보를 업데이트할 수 있는 프로필 수정 기능을 추가하여, 사용자가 자신의 정보를 손쉽게 변경할 수 있게 되었습니다.
- **개선 사항**
	- 회원 정보 조회 설명을 명확하게 개선해 사용자 친화적인 경험을 제공합니다.
	- 정보 수정 시 데이터 검증과 트랜잭션 관리가 강화되어 안정성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
