### PR TITLE
[YS-256] feat: 회원가입 연락 받을 이메일 중복 비허용 로직 추가

### DIFF
--- a/src/main/kotlin/com/dobby/backend/application/service/MemberService.kt
+++ b/src/main/kotlin/com/dobby/backend/application/service/MemberService.kt
@@ -12,6 +12,7 @@ class MemberService(
     private val memberGateway: MemberGateway,
     private val createParticipantUseCase: CreateParticipantUseCase,
     private val createResearcherUseCase: CreateResearcherUseCase,
+    private val verifyContactEmailUseCase: VerifyContactEmailUseCase,
     private val verifyResearcherEmailUseCase: VerifyResearcherEmailUseCase,
     private val getResearcherInfoUseCase: GetResearcherInfoUseCase,
     private val getParticipantInfoUseCase: GetParticipantInfoUseCase,
@@ -30,6 +31,11 @@ class MemberService(
 
         verifyResearcherEmailUseCase.execute(input.univEmail)
         return createResearcherUseCase.execute(input)
+    }
+
+    @Transactional
+    fun validateDuplicatedContactEmail(input: VerifyContactEmailUseCase.Input) : VerifyContactEmailUseCase.Output{
+        return verifyContactEmailUseCase.execute(input)
     }
 
     @Transactional

--- a/src/main/kotlin/com/dobby/backend/application/usecase/member/VerifyContactEmailUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/member/VerifyContactEmailUseCase.kt
@@ -1,7 +1,7 @@
 package com.dobby.backend.application.usecase.member
 
 import com.dobby.backend.application.usecase.UseCase
-import com.dobby.backend.domain.exception.SignupContactEmailDuplicateException
+import com.dobby.backend.domain.exception.ContactEmailDuplicateException
 import com.dobby.backend.domain.gateway.member.MemberGateway
 
 class VerifyContactEmailUseCase(
@@ -16,7 +16,9 @@ class VerifyContactEmailUseCase(
     )
 
     override fun execute(input: Input): Output {
-        if(memberGateway.findByContactEmail(input.contactEmail) == null) return Output(success = true)
-        else throw SignupContactEmailDuplicateException
+        if(!memberGateway.existsByContactEmail(input.contactEmail))
+            return Output(success = true)
+        else
+            throw ContactEmailDuplicateException
     }
 }

--- a/src/main/kotlin/com/dobby/backend/application/usecase/member/VerifyContactEmailUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/member/VerifyContactEmailUseCase.kt
@@ -1,0 +1,22 @@
+package com.dobby.backend.application.usecase.member
+
+import com.dobby.backend.application.usecase.UseCase
+import com.dobby.backend.domain.exception.SignupContactEmailDuplicateException
+import com.dobby.backend.domain.gateway.member.MemberGateway
+
+class VerifyContactEmailUseCase(
+    private val memberGateway: MemberGateway
+): UseCase<VerifyContactEmailUseCase.Input, VerifyContactEmailUseCase.Output> {
+    data class Input(
+        val contactEmail: String
+    )
+
+    data class Output(
+        val success: Boolean
+    )
+
+    override fun execute(input: Input): Output {
+        if(memberGateway.findByContactEmail(input.contactEmail) == null) return Output(success = true)
+        else throw SignupContactEmailDuplicateException
+    }
+}

--- a/src/main/kotlin/com/dobby/backend/domain/exception/DobbyException.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/exception/DobbyException.kt
@@ -51,7 +51,7 @@ data object ResearcherNotFoundException : ClientException("ME0003", "Researcher 
 data object ParticipantNotFoundException : ClientException("ME0004", "Participant Not Found.", HttpStatus.NOT_FOUND)
 data object EmailNotValidateException : ClientException("ME0005", "You should validate your school email first", HttpStatus.BAD_REQUEST)
 data object SignupOauthEmailDuplicateException : ClientException("ME0006", "You've already joined with requested oauth email", HttpStatus.CONFLICT)
-data object SignupContactEmailDuplicateException: ClientException("ME0007", "You've already joined with requested contact email", HttpStatus.CONFLICT)
+data object ContactEmailDuplicateException: ClientException("ME0007", "This contact email is already in use", HttpStatus.CONFLICT)
 /**
  * Experiment error codes
  */

--- a/src/main/kotlin/com/dobby/backend/domain/exception/DobbyException.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/exception/DobbyException.kt
@@ -51,7 +51,7 @@ data object ResearcherNotFoundException : ClientException("ME0003", "Researcher 
 data object ParticipantNotFoundException : ClientException("ME0004", "Participant Not Found.", HttpStatus.NOT_FOUND)
 data object EmailNotValidateException : ClientException("ME0005", "You should validate your school email first", HttpStatus.BAD_REQUEST)
 data object SignupOauthEmailDuplicateException : ClientException("ME0006", "You've already joined with requested oauth email", HttpStatus.CONFLICT)
-
+data object SignupContactEmailDuplicateException: ClientException("ME007", "You've already joined with requested contact email", HttpStatus.CONFLICT)
 /**
  * Experiment error codes
  */

--- a/src/main/kotlin/com/dobby/backend/domain/exception/DobbyException.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/exception/DobbyException.kt
@@ -51,7 +51,7 @@ data object ResearcherNotFoundException : ClientException("ME0003", "Researcher 
 data object ParticipantNotFoundException : ClientException("ME0004", "Participant Not Found.", HttpStatus.NOT_FOUND)
 data object EmailNotValidateException : ClientException("ME0005", "You should validate your school email first", HttpStatus.BAD_REQUEST)
 data object SignupOauthEmailDuplicateException : ClientException("ME0006", "You've already joined with requested oauth email", HttpStatus.CONFLICT)
-data object SignupContactEmailDuplicateException: ClientException("ME007", "You've already joined with requested contact email", HttpStatus.CONFLICT)
+data object SignupContactEmailDuplicateException: ClientException("ME0007", "You've already joined with requested contact email", HttpStatus.CONFLICT)
 /**
  * Experiment error codes
  */

--- a/src/main/kotlin/com/dobby/backend/domain/gateway/member/MemberGateway.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/gateway/member/MemberGateway.kt
@@ -6,6 +6,7 @@ import com.dobby.backend.infrastructure.database.entity.enums.MemberStatus
 interface MemberGateway {
     fun getById(memberId: String): Member
     fun findById(memberId: String): Member?
+    fun findByContactEmail(contactEmail: String): Member?
     fun findByOauthEmailAndStatus(email: String, status: MemberStatus): Member?
     fun findByOauthEmail(email: String): Member?
     fun save(savedMember: Member) : Member

--- a/src/main/kotlin/com/dobby/backend/domain/gateway/member/MemberGateway.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/gateway/member/MemberGateway.kt
@@ -6,7 +6,7 @@ import com.dobby.backend.infrastructure.database.entity.enums.MemberStatus
 interface MemberGateway {
     fun getById(memberId: String): Member
     fun findById(memberId: String): Member?
-    fun findByContactEmail(contactEmail: String): Member?
+    fun existsByContactEmail(contactEmail: String): Boolean
     fun findByOauthEmailAndStatus(email: String, status: MemberStatus): Member?
     fun findByOauthEmail(email: String): Member?
     fun save(savedMember: Member) : Member

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/member/MemberEntity.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/member/MemberEntity.kt
@@ -30,7 +30,7 @@ class MemberEntity(
     @Enumerated(EnumType.STRING)
     val role: RoleType?,
 
-    @Column(name = "contact_email", length = 100, nullable = true)
+    @Column(name = "contact_email", length = 100, nullable = true, unique = true)
     val contactEmail: String?,
 
     @Column(name = "name", length = 10, nullable = true)

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/repository/MemberRepository.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/repository/MemberRepository.kt
@@ -6,5 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface MemberRepository : JpaRepository<MemberEntity, String> {
     fun findByOauthEmail(oauthEmail: String): MemberEntity?
+    fun findByContactEmail(contactEmail: String): MemberEntity?
     fun findByOauthEmailAndStatus(oauthEmail: String, status: MemberStatus): MemberEntity?
 }

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/repository/MemberRepository.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/repository/MemberRepository.kt
@@ -6,6 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface MemberRepository : JpaRepository<MemberEntity, String> {
     fun findByOauthEmail(oauthEmail: String): MemberEntity?
-    fun findByContactEmail(contactEmail: String): MemberEntity?
+    fun existsByContactEmail(contactEmail: String): Boolean
     fun findByOauthEmailAndStatus(oauthEmail: String, status: MemberStatus): MemberEntity?
 }

--- a/src/main/kotlin/com/dobby/backend/infrastructure/gateway/member/MemberGatewayImpl.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/gateway/member/MemberGatewayImpl.kt
@@ -24,6 +24,12 @@ class MemberGatewayImpl(
             .orElse(null)
     }
 
+    override fun findByContactEmail(memberId: String): Member? {
+        return memberRepository
+            .findByContactEmail(memberId)
+            ?.let(MemberEntity::toDomain)
+    }
+
     override fun findByOauthEmailAndStatus(email: String, status: MemberStatus): Member? {
         return memberRepository
             .findByOauthEmailAndStatus(email, status)

--- a/src/main/kotlin/com/dobby/backend/infrastructure/gateway/member/MemberGatewayImpl.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/gateway/member/MemberGatewayImpl.kt
@@ -24,9 +24,9 @@ class MemberGatewayImpl(
             .orElse(null)
     }
 
-    override fun findByContactEmail(memberId: String): Member? {
+    override fun findByContactEmail(contactEmail: String): Member? {
         return memberRepository
-            .findByContactEmail(memberId)
+            .findByContactEmail(contactEmail)
             ?.let(MemberEntity::toDomain)
     }
 

--- a/src/main/kotlin/com/dobby/backend/infrastructure/gateway/member/MemberGatewayImpl.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/gateway/member/MemberGatewayImpl.kt
@@ -24,10 +24,8 @@ class MemberGatewayImpl(
             .orElse(null)
     }
 
-    override fun findByContactEmail(contactEmail: String): Member? {
-        return memberRepository
-            .findByContactEmail(contactEmail)
-            ?.let(MemberEntity::toDomain)
+    override fun existsByContactEmail(contactEmail: String): Boolean {
+        return memberRepository.existsByContactEmail(contactEmail)
     }
 
     override fun findByOauthEmailAndStatus(email: String, status: MemberStatus): Member? {

--- a/src/main/kotlin/com/dobby/backend/presentation/api/controller/MemberController.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/controller/MemberController.kt
@@ -48,15 +48,15 @@ class MemberController(
         return MemberMapper.toResearcherSignupResponse(output)
     }
 
-    @PostMapping("/signup/validate/contact-email")
+    @GetMapping("/signup/validate/contact-email")
     @Operation(
         summary = "연락 받을 이메일 주소 검증 API - 회원가입 시 필수 API",
         description = "연락 받을 이메일이 사용 가능한지 검증해주는 API입니다. 사용가능하면 true, 아니면 예외를 던집니다."
     )
     fun emailAvailableCheck(
-        @RequestBody @Valid req: ContactEmailVerificationRequest
+        @RequestParam contactEmail: String
     ) : DefaultResponse {
-        val input = MemberMapper.toContactEmailVerificationInput(req)
+        val input = MemberMapper.toContactEmailVerificationInput(contactEmail)
         val output = memberService.validateDuplicatedContactEmail(input)
         return MemberMapper.toContactEmailVerificationResponse(output)
     }

--- a/src/main/kotlin/com/dobby/backend/presentation/api/controller/MemberController.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/controller/MemberController.kt
@@ -1,10 +1,8 @@
 package com.dobby.backend.presentation.api.controller
 
 import com.dobby.backend.application.service.MemberService
-import com.dobby.backend.presentation.api.dto.request.member.ParticipantSignupRequest
-import com.dobby.backend.presentation.api.dto.request.member.ResearcherSignupRequest
-import com.dobby.backend.presentation.api.dto.request.member.UpdateParticipantInfoRequest
-import com.dobby.backend.presentation.api.dto.request.member.UpdateResearcherInfoRequest
+import com.dobby.backend.presentation.api.dto.request.member.*
+import com.dobby.backend.presentation.api.dto.response.member.DefaultResponse
 import com.dobby.backend.presentation.api.dto.response.member.ParticipantInfoResponse
 import com.dobby.backend.presentation.api.dto.response.member.ResearcherInfoResponse
 import com.dobby.backend.presentation.api.dto.response.member.SignupResponse
@@ -48,6 +46,19 @@ class MemberController(
         val input = MemberMapper.toCreateResearcherInput(req)
         val output = memberService.researcherSignup(input)
         return MemberMapper.toResearcherSignupResponse(output)
+    }
+
+    @PostMapping("/signup/validate/contact-email")
+    @Operation(
+        summary = "연락 받을 이메일 주소 검증 API - 회원가입 시 필수 API",
+        description = "연락 받을 이메일이 사용 가능한지 검증해주는 API입니다. 사용가능하면 true, 아니면 예외를 던집니다."
+    )
+    fun emailAvailableCheck(
+        @RequestBody @Valid req: ContactEmailVerificationRequest
+    ) : DefaultResponse {
+        val input = MemberMapper.toContactEmailVerificationInput(req)
+        val output = memberService.validateDuplicatedContactEmail(input)
+        return MemberMapper.toContactEmailVerificationResponse(output)
     }
 
     @PreAuthorize("hasRole('RESEARCHER')")

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/member/ContactEmailVerificationRequest.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/member/ContactEmailVerificationRequest.kt
@@ -1,0 +1,12 @@
+package com.dobby.backend.presentation.api.dto.request.member
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+
+data class ContactEmailVerificationRequest (
+    @Email(message= "연락 받을 이메일이 유효하지 않습니다.")
+    @NotBlank(message = "연락 받을 이메일은 공백일 수 없습니다.")
+    @Schema(description = "연락 받을 이메일")
+    val contactEmail: String,
+)

--- a/src/main/kotlin/com/dobby/backend/presentation/api/mapper/MemberMapper.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/mapper/MemberMapper.kt
@@ -4,10 +4,7 @@ import com.dobby.backend.application.usecase.member.*
 import com.dobby.backend.domain.model.member.Participant
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Area
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region
-import com.dobby.backend.presentation.api.dto.request.member.ParticipantSignupRequest
-import com.dobby.backend.presentation.api.dto.request.member.ResearcherSignupRequest
-import com.dobby.backend.presentation.api.dto.request.member.UpdateParticipantInfoRequest
-import com.dobby.backend.presentation.api.dto.request.member.UpdateResearcherInfoRequest
+import com.dobby.backend.presentation.api.dto.request.member.*
 import com.dobby.backend.presentation.api.dto.response.member.*
 import com.dobby.backend.util.getCurrentMemberId
 
@@ -58,6 +55,18 @@ object MemberMapper {
             accessToken = output.accessToken,
             refreshToken = output.refreshToken,
             memberInfo = toMemberResDto(output.memberInfo)
+        )
+    }
+
+    fun toContactEmailVerificationInput(req: ContactEmailVerificationRequest): VerifyContactEmailUseCase.Input{
+        return VerifyContactEmailUseCase.Input(
+            contactEmail = req.contactEmail
+        )
+    }
+
+    fun toContactEmailVerificationResponse(output: VerifyContactEmailUseCase.Output): DefaultResponse{
+        return DefaultResponse(
+            success = output.success
         )
     }
 

--- a/src/main/kotlin/com/dobby/backend/presentation/api/mapper/MemberMapper.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/mapper/MemberMapper.kt
@@ -58,9 +58,9 @@ object MemberMapper {
         )
     }
 
-    fun toContactEmailVerificationInput(req: ContactEmailVerificationRequest): VerifyContactEmailUseCase.Input{
+    fun toContactEmailVerificationInput(contactEmail: String): VerifyContactEmailUseCase.Input{
         return VerifyContactEmailUseCase.Input(
-            contactEmail = req.contactEmail
+            contactEmail = contactEmail
         )
     }
 

--- a/src/test/kotlin/com/dobby/backend/application/usecase/member/VerifyContactEmailUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/member/VerifyContactEmailUseCaseTest.kt
@@ -1,6 +1,6 @@
 package com.dobby.backend.application.usecase.member
 
-import com.dobby.backend.domain.exception.SignupContactEmailDuplicateException
+import com.dobby.backend.domain.exception.ContactEmailDuplicateException
 import com.dobby.backend.domain.gateway.member.MemberGateway
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
@@ -18,7 +18,7 @@ class VerifyContactEmailUseCaseTest : BehaviorSpec({
         `when`("이메일이 데이터베이스에 존재하지 않는 경우") {
             val input = VerifyContactEmailUseCase.Input(contactEmail = "newuser@example.com")
 
-            every { memberGateway.findByContactEmail(input.contactEmail) } returns null
+            every { memberGateway.existsByContactEmail(input.contactEmail) } returns false
 
             then("이메일 사용 가능 응답을 반환해야 한다") {
                 val result = verifyContactEmailUseCase.execute(input)
@@ -29,10 +29,10 @@ class VerifyContactEmailUseCaseTest : BehaviorSpec({
         `when`("이메일이 이미 존재하는 경우") {
             val input = VerifyContactEmailUseCase.Input(contactEmail = "existinguser@example.com")
 
-            every { memberGateway.findByContactEmail(input.contactEmail) } returns mockk()
+            every { memberGateway.existsByContactEmail(input.contactEmail) } returns true
 
-            then("SignupContactEmailDuplicateException 예외가 발생해야 한다") {
-                shouldThrow<SignupContactEmailDuplicateException> {
+            then("ContactEmailDuplication 예외가 발생해야 한다") {
+                shouldThrow<ContactEmailDuplicateException> {
                     verifyContactEmailUseCase.execute(input)
                 }
             }

--- a/src/test/kotlin/com/dobby/backend/application/usecase/member/VerifyContactEmailUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/member/VerifyContactEmailUseCaseTest.kt
@@ -1,0 +1,41 @@
+package com.dobby.backend.application.usecase.member
+
+import com.dobby.backend.domain.exception.SignupContactEmailDuplicateException
+import com.dobby.backend.domain.gateway.member.MemberGateway
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.assertions.throwables.shouldThrow
+import io.mockk.every
+import io.mockk.mockk
+
+class VerifyContactEmailUseCaseTest : BehaviorSpec({
+
+    val memberGateway = mockk<MemberGateway>()
+    val verifyContactEmailUseCase = VerifyContactEmailUseCase(memberGateway)
+
+    given("회원 가입 시 이메일 중복 확인") {
+
+        `when`("이메일이 데이터베이스에 존재하지 않는 경우") {
+            val input = VerifyContactEmailUseCase.Input(contactEmail = "newuser@example.com")
+
+            every { memberGateway.findByContactEmail(input.contactEmail) } returns null
+
+            then("이메일 사용 가능 응답을 반환해야 한다") {
+                val result = verifyContactEmailUseCase.execute(input)
+                result.success shouldBe true
+            }
+        }
+
+        `when`("이메일이 이미 존재하는 경우") {
+            val input = VerifyContactEmailUseCase.Input(contactEmail = "existinguser@example.com")
+
+            every { memberGateway.findByContactEmail(input.contactEmail) } returns mockk()
+
+            then("SignupContactEmailDuplicateException 예외가 발생해야 한다") {
+                shouldThrow<SignupContactEmailDuplicateException> {
+                    verifyContactEmailUseCase.execute(input)
+                }
+            }
+        }
+    }
+})


### PR DESCRIPTION
## 💡 작업 내용
- 변경된 기획안에 따라, 회원가입 시에 연락받을 이메일 (contactEmail)에 대한 중복을 비허용하는 로직을 구현했습니다.
- 프론트와 협의 하에 API를 추가로 개설(`/signup/validate/contact-email`) 했습니다.

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- 관련된 Discussion 등이 있다면 첨부해주세요
### case 1) 가입 가능한 이메일일 때 - 200 OK
<img src="https://github.com/user-attachments/assets/d40115f8-2694-4380-8db7-b71d3798a4f3" width="50%" /></br>
### case 2) 이미 가입하여 불가능한 이메일일 때 - 403 CONFLICT
<img src="https://github.com/user-attachments/assets/1408f43e-0115-4d66-ac5f-67b66b07a6d9" width="50%" />



## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-256

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **신규 기능**
	- 회원가입 시 이메일 중복 여부를 실시간으로 확인할 수 있는 기능이 추가되었습니다.
	- 이메일 형식 검증을 위한 새로운 요청 데이터 클래스가 도입되었습니다.
	- 이메일 중복 확인을 위한 API 엔드포인트가 추가되었습니다.
	- 이메일 중복 검증 프로세스를 지원하는 매퍼 기능이 추가되었습니다.
- **버그 수정**
	- 이메일 중복 시 명확한 예외 처리가 추가되었습니다.
- **변경 사항**
	- 데이터베이스에서 이메일 필드의 고유성 제약 조건이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-256