### PR TITLE
[YS-233] feat: 회원 탈퇴 API 구현

### DIFF
--- a/src/main/kotlin/com/dobby/backend/application/service/MemberService.kt
+++ b/src/main/kotlin/com/dobby/backend/application/service/MemberService.kt
@@ -3,7 +3,7 @@ package com.dobby.backend.application.service
 import com.dobby.backend.application.usecase.member.*
 import com.dobby.backend.domain.exception.SignupOauthEmailDuplicateException
 import com.dobby.backend.domain.gateway.member.MemberGateway
-import com.dobby.backend.infrastructure.database.entity.enums.MemberStatus
+import com.dobby.backend.infrastructure.database.entity.enums.member.MemberStatus
 import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
 

--- a/src/main/kotlin/com/dobby/backend/application/service/MemberService.kt
+++ b/src/main/kotlin/com/dobby/backend/application/service/MemberService.kt
@@ -18,7 +18,8 @@ class MemberService(
     private val getParticipantInfoUseCase: GetParticipantInfoUseCase,
     private val updateResearcherInfoUseCase: UpdateResearcherInfoUseCase,
     private val updateParticipantInfoUseCase: UpdateParticipantInfoUseCase,
-    private val validateContactEmailForUpdateUseCase: ValidateContactEmailForUpdateUseCase
+    private val validateContactEmailForUpdateUseCase: ValidateContactEmailForUpdateUseCase,
+    private val deleteMemberUseCase: DeleteMemberUseCase
 ) {
     @Transactional
     fun participantSignup(input: CreateParticipantUseCase.Input): CreateParticipantUseCase.Output {
@@ -61,5 +62,10 @@ class MemberService(
 
     fun validateContactEmailForUpdate(input: ValidateContactEmailForUpdateUseCase.Input): ValidateContactEmailForUpdateUseCase.Output {
         return validateContactEmailForUpdateUseCase.execute(input)
+    }
+
+    @Transactional
+    fun deleteMember(input: DeleteMemberUseCase.Input): DeleteMemberUseCase.Output {
+        return deleteMemberUseCase.execute(input)
     }
 }

--- a/src/main/kotlin/com/dobby/backend/application/service/MemberService.kt
+++ b/src/main/kotlin/com/dobby/backend/application/service/MemberService.kt
@@ -1,9 +1,11 @@
 package com.dobby.backend.application.service
 
 import com.dobby.backend.application.usecase.member.*
+import com.dobby.backend.domain.exception.MemberNotFoundException
 import com.dobby.backend.domain.exception.SignupOauthEmailDuplicateException
 import com.dobby.backend.domain.gateway.member.MemberGateway
 import com.dobby.backend.infrastructure.database.entity.enums.member.MemberStatus
+import com.dobby.backend.infrastructure.database.entity.enums.member.RoleType
 import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
 
@@ -19,7 +21,8 @@ class MemberService(
     private val updateResearcherInfoUseCase: UpdateResearcherInfoUseCase,
     private val updateParticipantInfoUseCase: UpdateParticipantInfoUseCase,
     private val validateContactEmailForUpdateUseCase: ValidateContactEmailForUpdateUseCase,
-    private val deleteMemberUseCase: DeleteMemberUseCase
+    private val deleteParticipantUseCase: DeleteParticipantUseCase,
+    private val deleteResearcherUseCase: DeleteResearcherUseCase
 ) {
     @Transactional
     fun participantSignup(input: CreateParticipantUseCase.Input): CreateParticipantUseCase.Output {
@@ -65,7 +68,16 @@ class MemberService(
     }
 
     @Transactional
-    fun deleteMember(input: DeleteMemberUseCase.Input): DeleteMemberUseCase.Output {
-        return deleteMemberUseCase.execute(input)
+    fun deleteMember(input: Any): Any {
+        return when (input) {
+            is DeleteParticipantUseCase.Input -> deleteParticipantUseCase.execute(input)
+            is DeleteResearcherUseCase.Input -> deleteResearcherUseCase.execute(input)
+            else -> throw IllegalArgumentException("Unsupported DeleteMember input type")
+        }
+    }
+
+    fun getMemberRole(memberId: String): RoleType {
+        return memberGateway.findRoleByIdAndDeletedAtIsNull(memberId)
+            ?: throw MemberNotFoundException
     }
 }

--- a/src/main/kotlin/com/dobby/backend/application/usecase/auth/FetchGoogleUserInfoUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/auth/FetchGoogleUserInfoUseCase.kt
@@ -5,9 +5,9 @@ import com.dobby.backend.domain.exception.MemberRoleMismatchException
 import com.dobby.backend.domain.gateway.member.MemberGateway
 import com.dobby.backend.domain.gateway.auth.TokenGateway
 import com.dobby.backend.domain.gateway.auth.GoogleAuthGateway
-import com.dobby.backend.infrastructure.database.entity.enums.MemberStatus
-import com.dobby.backend.infrastructure.database.entity.enums.ProviderType
-import com.dobby.backend.infrastructure.database.entity.enums.RoleType
+import com.dobby.backend.infrastructure.database.entity.enums.member.MemberStatus
+import com.dobby.backend.infrastructure.database.entity.enums.member.ProviderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.RoleType
 
 class FetchGoogleUserInfoUseCase(
     private val googleAuthGateway: GoogleAuthGateway,

--- a/src/main/kotlin/com/dobby/backend/application/usecase/auth/FetchNaverUserInfoUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/auth/FetchNaverUserInfoUseCase.kt
@@ -5,9 +5,9 @@ import com.dobby.backend.domain.exception.MemberRoleMismatchException
 import com.dobby.backend.domain.gateway.member.MemberGateway
 import com.dobby.backend.domain.gateway.auth.NaverAuthGateway
 import com.dobby.backend.domain.gateway.auth.TokenGateway
-import com.dobby.backend.infrastructure.database.entity.enums.MemberStatus
-import com.dobby.backend.infrastructure.database.entity.enums.ProviderType
-import com.dobby.backend.infrastructure.database.entity.enums.RoleType
+import com.dobby.backend.infrastructure.database.entity.enums.member.MemberStatus
+import com.dobby.backend.infrastructure.database.entity.enums.member.ProviderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.RoleType
 
 class FetchNaverUserInfoUseCase(
     private val naverAuthGateway: NaverAuthGateway,

--- a/src/main/kotlin/com/dobby/backend/application/usecase/auth/GenerateTestTokenUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/auth/GenerateTestTokenUseCase.kt
@@ -22,7 +22,7 @@ class GenerateTestTokenUseCase(
 
     override fun execute(input: Input): Output {
         val memberId = input.memberId
-        val member = memberGateway.findById(memberId)
+        val member = memberGateway.findByIdAndDeletedAtIsNull(memberId)
             ?: throw MemberNotFoundException
 
         return Output(

--- a/src/main/kotlin/com/dobby/backend/application/usecase/experiment/CreateExperimentPostUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/experiment/CreateExperimentPostUseCase.kt
@@ -10,10 +10,10 @@ import com.dobby.backend.domain.model.experiment.ExperimentImage
 import com.dobby.backend.domain.model.experiment.ExperimentPost
 import com.dobby.backend.domain.model.experiment.TargetGroup
 import com.dobby.backend.domain.model.member.Member
-import com.dobby.backend.infrastructure.database.entity.enums.GenderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.GenderType
 import com.dobby.backend.infrastructure.database.entity.enums.MatchType
-import com.dobby.backend.infrastructure.database.entity.enums.RoleType
-import com.dobby.backend.infrastructure.database.entity.enums.TimeSlot
+import com.dobby.backend.infrastructure.database.entity.enums.member.RoleType
+import com.dobby.backend.infrastructure.database.entity.enums.experiment.TimeSlot
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Area
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region
 import java.time.LocalDate

--- a/src/main/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostDetailUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostDetailUseCase.kt
@@ -45,7 +45,8 @@ fun ExperimentPost.toDetailResponse(memberId: String?): ExperimentPostDetailResp
         address = this.toAddressResponse(),
         content = this.content,
         imageList = this.images.map { it.imageUrl },
-        isAuthor = this.member.id == memberId
+        isAuthor = this.member.id == memberId,
+        isUploaderActive = this.member.deletedAt == null
     )
 }
 

--- a/src/main/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostsUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostsUseCase.kt
@@ -6,7 +6,7 @@ import com.dobby.backend.domain.gateway.experiment.ExperimentPostGateway
 import com.dobby.backend.domain.model.experiment.CustomFilter
 import com.dobby.backend.domain.model.experiment.LocationTarget
 import com.dobby.backend.domain.model.experiment.StudyTarget
-import com.dobby.backend.infrastructure.database.entity.enums.GenderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.GenderType
 import com.dobby.backend.infrastructure.database.entity.enums.MatchType
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Area
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region

--- a/src/main/kotlin/com/dobby/backend/application/usecase/experiment/UpdateExperimentPostUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/experiment/UpdateExperimentPostUseCase.kt
@@ -4,9 +4,9 @@ import com.dobby.backend.application.usecase.UseCase
 import com.dobby.backend.domain.exception.*
 import com.dobby.backend.domain.gateway.experiment.ExperimentPostGateway
 import com.dobby.backend.domain.model.experiment.ExperimentPost
-import com.dobby.backend.infrastructure.database.entity.enums.GenderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.GenderType
 import com.dobby.backend.infrastructure.database.entity.enums.MatchType
-import com.dobby.backend.infrastructure.database.entity.enums.TimeSlot
+import com.dobby.backend.infrastructure.database.entity.enums.experiment.TimeSlot
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Area
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region
 import java.time.LocalDate

--- a/src/main/kotlin/com/dobby/backend/application/usecase/member/CreateParticipantUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/member/CreateParticipantUseCase.kt
@@ -9,6 +9,9 @@ import com.dobby.backend.domain.model.member.Participant
 import com.dobby.backend.infrastructure.database.entity.enums.*
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Area
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region
+import com.dobby.backend.infrastructure.database.entity.enums.member.GenderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.ProviderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.RoleType
 import java.time.LocalDate
 
 class CreateParticipantUseCase (

--- a/src/main/kotlin/com/dobby/backend/application/usecase/member/CreateResearcherUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/member/CreateResearcherUseCase.kt
@@ -7,7 +7,9 @@ import com.dobby.backend.domain.gateway.member.ResearcherGateway
 import com.dobby.backend.domain.gateway.auth.TokenGateway
 import com.dobby.backend.domain.model.member.Member
 import com.dobby.backend.domain.model.member.Researcher
-import com.dobby.backend.infrastructure.database.entity.enums.*
+import com.dobby.backend.infrastructure.database.entity.enums.member.MemberStatus
+import com.dobby.backend.infrastructure.database.entity.enums.member.ProviderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.RoleType
 
 class CreateResearcherUseCase(
     private val memberGateway: MemberGateway,

--- a/src/main/kotlin/com/dobby/backend/application/usecase/member/DeleteMemberUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/member/DeleteMemberUseCase.kt
@@ -1,0 +1,39 @@
+package com.dobby.backend.application.usecase.member
+
+import com.dobby.backend.application.usecase.UseCase
+import com.dobby.backend.domain.exception.MemberNotFoundException
+import com.dobby.backend.domain.gateway.member.MemberGateway
+import com.dobby.backend.domain.gateway.member.MemberWithdrawalGateway
+import com.dobby.backend.domain.model.member.MemberWithdrawal
+import com.dobby.backend.infrastructure.database.entity.enums.member.WithdrawalReasonType
+
+class DeleteMemberUseCase(
+    private val memberGateway: MemberGateway,
+    private val memberWithdrawalGateway: MemberWithdrawalGateway
+) : UseCase<DeleteMemberUseCase.Input, DeleteMemberUseCase.Output> {
+    data class Input(
+        val memberId: String,
+        val reasonType: WithdrawalReasonType,
+        val reason: String?
+    )
+
+    data class Output(
+        val isSuccess: Boolean
+    )
+
+    override fun execute(input: Input): Output {
+        val member = memberGateway.findByIdAndDeletedAtIsNull(input.memberId)
+            ?: throw MemberNotFoundException
+
+        memberGateway.save(member.withdraw())
+        memberWithdrawalGateway.save(
+            MemberWithdrawal.newWithdrawal(
+                memberId = input.memberId,
+                reasonType = input.reasonType,
+                otherReason = input.reason
+            )
+        )
+
+        return Output(isSuccess = true)
+    }
+}

--- a/src/main/kotlin/com/dobby/backend/application/usecase/member/DeleteParticipantUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/member/DeleteParticipantUseCase.kt
@@ -7,10 +7,10 @@ import com.dobby.backend.domain.gateway.member.MemberWithdrawalGateway
 import com.dobby.backend.domain.model.member.MemberWithdrawal
 import com.dobby.backend.infrastructure.database.entity.enums.member.WithdrawalReasonType
 
-class DeleteMemberUseCase(
+class DeleteParticipantUseCase(
     private val memberGateway: MemberGateway,
     private val memberWithdrawalGateway: MemberWithdrawalGateway
-) : UseCase<DeleteMemberUseCase.Input, DeleteMemberUseCase.Output> {
+) : UseCase<DeleteParticipantUseCase.Input, DeleteParticipantUseCase.Output> {
     data class Input(
         val memberId: String,
         val reasonType: WithdrawalReasonType,
@@ -26,6 +26,7 @@ class DeleteMemberUseCase(
             ?: throw MemberNotFoundException
 
         memberGateway.save(member.withdraw())
+
         memberWithdrawalGateway.save(
             MemberWithdrawal.newWithdrawal(
                 memberId = input.memberId,

--- a/src/main/kotlin/com/dobby/backend/application/usecase/member/DeleteResearcherUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/member/DeleteResearcherUseCase.kt
@@ -1,0 +1,44 @@
+package com.dobby.backend.application.usecase.member
+
+import com.dobby.backend.application.usecase.UseCase
+import com.dobby.backend.domain.exception.MemberNotFoundException
+import com.dobby.backend.domain.gateway.email.VerificationGateway
+import com.dobby.backend.domain.gateway.member.MemberWithdrawalGateway
+import com.dobby.backend.domain.gateway.member.ResearcherGateway
+import com.dobby.backend.domain.model.member.MemberWithdrawal
+import com.dobby.backend.infrastructure.database.entity.enums.member.WithdrawalReasonType
+
+class DeleteResearcherUseCase(
+    private val researcherGateway: ResearcherGateway,
+    private val memberWithdrawalGateway: MemberWithdrawalGateway,
+    private val verificationGateway: VerificationGateway
+) : UseCase<DeleteResearcherUseCase.Input, DeleteResearcherUseCase.Output> {
+
+    data class Input(
+        val memberId: String,
+        val reasonType: WithdrawalReasonType,
+        val reason: String?
+    )
+
+    data class Output(
+        val isSuccess: Boolean
+    )
+
+    override fun execute(input: Input): Output {
+        val researcher = researcherGateway.findByMemberId(input.memberId)
+            ?: throw MemberNotFoundException
+
+        verificationGateway.deleteByUnivEmail(researcher.univEmail)
+        researcherGateway.save(researcher.withdraw())
+
+        memberWithdrawalGateway.save(
+            MemberWithdrawal.newWithdrawal(
+                memberId = input.memberId,
+                reasonType = input.reasonType,
+                otherReason = input.reason
+            )
+        )
+
+        return Output(isSuccess = true)
+    }
+}

--- a/src/main/kotlin/com/dobby/backend/application/usecase/member/GetParticipantInfoUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/member/GetParticipantInfoUseCase.kt
@@ -6,7 +6,7 @@ import com.dobby.backend.domain.gateway.member.MemberGateway
 import com.dobby.backend.domain.gateway.member.ParticipantGateway
 import com.dobby.backend.domain.model.member.Member
 import com.dobby.backend.domain.model.member.Participant
-import com.dobby.backend.infrastructure.database.entity.enums.GenderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.GenderType
 import com.dobby.backend.infrastructure.database.entity.enums.MatchType
 import java.time.LocalDate
 

--- a/src/main/kotlin/com/dobby/backend/application/usecase/member/UpdateParticipantInfoUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/member/UpdateParticipantInfoUseCase.kt
@@ -7,7 +7,7 @@ import com.dobby.backend.domain.gateway.member.MemberGateway
 import com.dobby.backend.domain.gateway.member.ParticipantGateway
 import com.dobby.backend.domain.model.member.Member
 import com.dobby.backend.domain.model.member.Participant
-import com.dobby.backend.infrastructure.database.entity.enums.GenderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.GenderType
 import com.dobby.backend.infrastructure.database.entity.enums.MatchType
 import java.time.LocalDate
 

--- a/src/main/kotlin/com/dobby/backend/domain/gateway/email/VerificationGateway.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/gateway/email/VerificationGateway.kt
@@ -8,4 +8,5 @@ interface VerificationGateway {
     fun findByUnivEmail(univEmail: String): Verification?
     fun save(verification: Verification): Verification
     fun updateCode(univEmail: String, code: String)
+    fun deleteByUnivEmail(univEmail: String)
 }

--- a/src/main/kotlin/com/dobby/backend/domain/gateway/member/MemberGateway.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/gateway/member/MemberGateway.kt
@@ -1,7 +1,7 @@
 package com.dobby.backend.domain.gateway.member
 
 import com.dobby.backend.domain.model.member.Member
-import com.dobby.backend.infrastructure.database.entity.enums.MemberStatus
+import com.dobby.backend.infrastructure.database.entity.enums.member.MemberStatus
 
 interface MemberGateway {
     fun getById(memberId: String): Member

--- a/src/main/kotlin/com/dobby/backend/domain/gateway/member/MemberGateway.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/gateway/member/MemberGateway.kt
@@ -2,6 +2,7 @@ package com.dobby.backend.domain.gateway.member
 
 import com.dobby.backend.domain.model.member.Member
 import com.dobby.backend.infrastructure.database.entity.enums.member.MemberStatus
+import com.dobby.backend.infrastructure.database.entity.enums.member.RoleType
 
 interface MemberGateway {
     fun getById(memberId: String): Member
@@ -12,4 +13,5 @@ interface MemberGateway {
     fun existsByContactEmail(contactEmail: String) : Boolean
     fun findContactEmailByMemberId(memberId: String): String
     fun findByContactEmail(contactEmail: String): Member?
+    fun findRoleByIdAndDeletedAtIsNull(memberId: String): RoleType?
 }

--- a/src/main/kotlin/com/dobby/backend/domain/gateway/member/MemberGateway.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/gateway/member/MemberGateway.kt
@@ -5,7 +5,7 @@ import com.dobby.backend.infrastructure.database.entity.enums.member.MemberStatu
 
 interface MemberGateway {
     fun getById(memberId: String): Member
-    fun findById(memberId: String): Member?
+    fun findByIdAndDeletedAtIsNull(memberId: String): Member?
     fun findByOauthEmailAndStatus(email: String, status: MemberStatus): Member?
     fun findByOauthEmail(email: String): Member?
     fun save(savedMember: Member) : Member

--- a/src/main/kotlin/com/dobby/backend/domain/gateway/member/MemberWithdrawalGateway.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/gateway/member/MemberWithdrawalGateway.kt
@@ -1,0 +1,7 @@
+package com.dobby.backend.domain.gateway.member
+
+import com.dobby.backend.domain.model.member.MemberWithdrawal
+
+interface MemberWithdrawalGateway {
+    fun save(memberWithdrawal: MemberWithdrawal): MemberWithdrawal
+}

--- a/src/main/kotlin/com/dobby/backend/domain/gateway/member/ResearcherGateway.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/gateway/member/ResearcherGateway.kt
@@ -4,6 +4,7 @@ import com.dobby.backend.domain.model.member.Researcher
 
 interface ResearcherGateway {
     fun findByMemberId(memberId: String): Researcher?
+    fun findByMemberIdAndMemberDeletedAtIsNull(memberId: String): Researcher?
 
     fun save(researcher: Researcher): Researcher
 }

--- a/src/main/kotlin/com/dobby/backend/domain/model/experiment/CustomFilter.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/model/experiment/CustomFilter.kt
@@ -1,6 +1,6 @@
 package com.dobby.backend.domain.model.experiment
 
-import com.dobby.backend.infrastructure.database.entity.enums.GenderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.GenderType
 import com.dobby.backend.infrastructure.database.entity.enums.MatchType
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Area
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region

--- a/src/main/kotlin/com/dobby/backend/domain/model/experiment/ExperimentPost.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/model/experiment/ExperimentPost.kt
@@ -4,7 +4,7 @@ import com.dobby.backend.domain.exception.ExperimentPostImageSizeException
 import com.dobby.backend.domain.exception.ExperimentPostInvalidOnlineRequestException
 import com.dobby.backend.domain.model.member.Member
 import com.dobby.backend.infrastructure.database.entity.enums.MatchType
-import com.dobby.backend.infrastructure.database.entity.enums.TimeSlot
+import com.dobby.backend.infrastructure.database.entity.enums.experiment.TimeSlot
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Area
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region
 import java.time.LocalDate

--- a/src/main/kotlin/com/dobby/backend/domain/model/experiment/TargetGroup.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/model/experiment/TargetGroup.kt
@@ -1,6 +1,6 @@
 package com.dobby.backend.domain.model.experiment
 
-import com.dobby.backend.infrastructure.database.entity.enums.GenderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.GenderType
 
 data class TargetGroup(
     val id: String,

--- a/src/main/kotlin/com/dobby/backend/domain/model/member/Member.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/model/member/Member.kt
@@ -1,5 +1,6 @@
 package com.dobby.backend.domain.model.member
 
+import com.dobby.backend.domain.policy.MemberMaskingPolicy
 import com.dobby.backend.infrastructure.database.entity.enums.member.MemberStatus
 import com.dobby.backend.infrastructure.database.entity.enums.member.ProviderType
 import com.dobby.backend.infrastructure.database.entity.enums.member.RoleType
@@ -41,9 +42,9 @@ data class Member(
     }
 
     fun withdraw(): Member = copy(
-        name = "ExMember",
-        oauthEmail = "Deleted_${id}",
-        contactEmail = "Deleted_${id}",
+        name = MemberMaskingPolicy.maskName(),
+        oauthEmail = MemberMaskingPolicy.maskSensitiveData(this.id),
+        contactEmail = MemberMaskingPolicy.maskSensitiveData(this.id),
         status = MemberStatus.HOLD,
         updatedAt = LocalDateTime.now(),
         deletedAt = LocalDateTime.now(),

--- a/src/main/kotlin/com/dobby/backend/domain/model/member/Member.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/model/member/Member.kt
@@ -15,7 +15,7 @@ data class Member(
     val role: RoleType?,
     val createdAt: LocalDateTime,
     val updatedAt: LocalDateTime,
-    val deletedAt: LocalDateTime? = null
+    val deletedAt: LocalDateTime?
 ) {
 
     companion object {
@@ -35,13 +35,17 @@ data class Member(
             status = MemberStatus.ACTIVE,
             role = role,
             createdAt = LocalDateTime.now(),
-            updatedAt = LocalDateTime.now()
+            updatedAt = LocalDateTime.now(),
+            deletedAt = null
         )
     }
 
     fun withdraw(): Member = copy(
+        name = "ExMember",
+        oauthEmail = "Deleted_${id}",
+        contactEmail = "Deleted_${id}",
         status = MemberStatus.HOLD,
+        updatedAt = LocalDateTime.now(),
         deletedAt = LocalDateTime.now(),
-        updatedAt = LocalDateTime.now()
     )
 }

--- a/src/main/kotlin/com/dobby/backend/domain/model/member/Member.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/model/member/Member.kt
@@ -1,8 +1,8 @@
 package com.dobby.backend.domain.model.member
 
-import com.dobby.backend.infrastructure.database.entity.enums.MemberStatus
-import com.dobby.backend.infrastructure.database.entity.enums.ProviderType
-import com.dobby.backend.infrastructure.database.entity.enums.RoleType
+import com.dobby.backend.infrastructure.database.entity.enums.member.MemberStatus
+import com.dobby.backend.infrastructure.database.entity.enums.member.ProviderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.RoleType
 import java.time.LocalDateTime
 
 data class Member(

--- a/src/main/kotlin/com/dobby/backend/domain/model/member/Member.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/model/member/Member.kt
@@ -14,7 +14,8 @@ data class Member(
     var status: MemberStatus,
     val role: RoleType?,
     val createdAt: LocalDateTime,
-    val updatedAt: LocalDateTime
+    val updatedAt: LocalDateTime,
+    val deletedAt: LocalDateTime? = null
 ) {
 
     companion object {
@@ -37,4 +38,10 @@ data class Member(
             updatedAt = LocalDateTime.now()
         )
     }
+
+    fun withdraw(): Member = copy(
+        status = MemberStatus.HOLD,
+        deletedAt = LocalDateTime.now(),
+        updatedAt = LocalDateTime.now()
+    )
 }

--- a/src/main/kotlin/com/dobby/backend/domain/model/member/MemberWithdrawal.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/model/member/MemberWithdrawal.kt
@@ -1,0 +1,25 @@
+package com.dobby.backend.domain.model.member
+
+import com.dobby.backend.infrastructure.database.entity.enums.member.WithdrawalReasonType
+import java.time.LocalDateTime
+
+data class MemberWithdrawal(
+    val memberId: String,
+    val reasonType: WithdrawalReasonType,
+    val otherReason: String? = null,
+    val createdAt: LocalDateTime
+) {
+    companion object {
+        fun newWithdrawal(
+            memberId: String,
+            reasonType: WithdrawalReasonType,
+            otherReason: String? = null,
+            createdAt: LocalDateTime = LocalDateTime.now()
+        ) = MemberWithdrawal(
+            memberId,
+            reasonType,
+            otherReason,
+            createdAt
+        )
+    }
+}

--- a/src/main/kotlin/com/dobby/backend/domain/model/member/Participant.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/model/member/Participant.kt
@@ -1,6 +1,6 @@
 package com.dobby.backend.domain.model.member
 
-import com.dobby.backend.infrastructure.database.entity.enums.GenderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.GenderType
 import com.dobby.backend.infrastructure.database.entity.enums.MatchType
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Area
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region

--- a/src/main/kotlin/com/dobby/backend/domain/model/member/Researcher.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/model/member/Researcher.kt
@@ -50,4 +50,12 @@ data class Researcher(
             labInfo = labInfo
         )
     }
+
+    fun withdraw(): Researcher = this.copy(
+        member = member.withdraw(),
+        univEmail = "",
+        univName = "",
+        major = "",
+        labInfo = null
+    )
 }

--- a/src/main/kotlin/com/dobby/backend/domain/model/member/Researcher.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/model/member/Researcher.kt
@@ -55,6 +55,7 @@ data class Researcher(
     fun withdraw(): Researcher = this.copy(
         member = member.withdraw(),
         univEmail = ResearcherMaskingPolicy.maskSensitiveData(this.id),
+        emailVerified = false,
         univName = ResearcherMaskingPolicy.maskSensitiveData(this.id),
         major = ResearcherMaskingPolicy.maskMajor(),
         labInfo = null

--- a/src/main/kotlin/com/dobby/backend/domain/model/member/Researcher.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/model/member/Researcher.kt
@@ -1,5 +1,6 @@
 package com.dobby.backend.domain.model.member
 
+import com.dobby.backend.domain.policy.ResearcherMaskingPolicy
 import java.time.LocalDateTime
 
 data class Researcher(
@@ -53,9 +54,9 @@ data class Researcher(
 
     fun withdraw(): Researcher = this.copy(
         member = member.withdraw(),
-        univEmail = "",
-        univName = "",
-        major = "",
+        univEmail = ResearcherMaskingPolicy.maskSensitiveData(this.id),
+        univName = ResearcherMaskingPolicy.maskSensitiveData(this.id),
+        major = ResearcherMaskingPolicy.maskMajor(),
         labInfo = null
     )
 }

--- a/src/main/kotlin/com/dobby/backend/domain/policy/MemberMaskingPolicy.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/policy/MemberMaskingPolicy.kt
@@ -1,0 +1,8 @@
+package com.dobby.backend.domain.policy
+
+class MemberMaskingPolicy {
+    companion object {
+        fun maskSensitiveData(id: String): String = "Deleted_${id}"
+        fun maskName(): String = "ExMember"
+    }
+}

--- a/src/main/kotlin/com/dobby/backend/domain/policy/ResearcherMaskingPolicy.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/policy/ResearcherMaskingPolicy.kt
@@ -1,0 +1,8 @@
+package com.dobby.backend.domain.policy
+
+class ResearcherMaskingPolicy {
+    companion object {
+        fun maskSensitiveData(id: String): String = "Deleted_${id}"
+        fun maskMajor(): String = "ExMajor"
+    }
+}

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/enums/GenderType.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/enums/GenderType.kt
@@ -1,5 +1,0 @@
-package com.dobby.backend.infrastructure.database.entity.enums
-
-enum class GenderType {
-    MALE, FEMALE, ALL
-}

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/enums/MemberStatus.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/enums/MemberStatus.kt
@@ -1,6 +1,0 @@
-package com.dobby.backend.infrastructure.database.entity.enums
-
-enum class MemberStatus {
-    HOLD,
-    ACTIVE
-}

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/enums/ProviderType.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/enums/ProviderType.kt
@@ -1,5 +1,0 @@
-package com.dobby.backend.infrastructure.database.entity.enums
-
-enum class ProviderType {
-    NAVER, GOOGLE
-}

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/enums/experiment/TimeSlot.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/enums/experiment/TimeSlot.kt
@@ -1,4 +1,4 @@
-package com.dobby.backend.infrastructure.database.entity.enums
+package com.dobby.backend.infrastructure.database.entity.enums.experiment
 
 enum class TimeSlot(
     val timeSlotName : String

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/enums/member/GenderType.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/enums/member/GenderType.kt
@@ -1,0 +1,5 @@
+package com.dobby.backend.infrastructure.database.entity.enums.member
+
+enum class GenderType {
+    MALE, FEMALE, ALL
+}

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/enums/member/MemberStatus.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/enums/member/MemberStatus.kt
@@ -1,0 +1,6 @@
+package com.dobby.backend.infrastructure.database.entity.enums.member
+
+enum class MemberStatus {
+    HOLD,
+    ACTIVE
+}

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/enums/member/ProviderType.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/enums/member/ProviderType.kt
@@ -1,0 +1,5 @@
+package com.dobby.backend.infrastructure.database.entity.enums.member
+
+enum class ProviderType {
+    NAVER, GOOGLE
+}

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/enums/member/RoleType.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/enums/member/RoleType.kt
@@ -1,4 +1,4 @@
-package com.dobby.backend.infrastructure.database.entity.enums
+package com.dobby.backend.infrastructure.database.entity.enums.member
 
 enum class RoleType(
     val roleName: String

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/enums/member/WithdrawalReasonType.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/enums/member/WithdrawalReasonType.kt
@@ -1,0 +1,12 @@
+package com.dobby.backend.infrastructure.database.entity.enums.member
+
+enum class WithdrawalReasonType(
+    val reasonType: String
+) {
+    RESEARCH_STOPPED("RESEARCH_STOPPED"),
+    SECURITY_CONCERN("SECURITY_CONCERN"),
+    NO_NECESSARY_FUNCTION("NO_NECESSARY_FUNCTION"),
+    TOO_MANY_EMAILS("TOO_MANY_EMAILS"),
+    INCONVENIENT_SITE("INCONVENIENT_SITE"),
+    OTHER("OTHER")
+}

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/experiment/ExperimentPostEntity.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/experiment/ExperimentPostEntity.kt
@@ -3,7 +3,7 @@ package com.dobby.backend.infrastructure.database.entity.experiment
 import com.dobby.backend.domain.model.experiment.ExperimentPost
 import com.dobby.backend.infrastructure.database.entity.member.MemberEntity
 import com.dobby.backend.infrastructure.database.entity.enums.MatchType
-import com.dobby.backend.infrastructure.database.entity.enums.TimeSlot
+import com.dobby.backend.infrastructure.database.entity.enums.experiment.TimeSlot
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Area
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region
 import jakarta.persistence.*

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/experiment/TargetGroupEntity.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/experiment/TargetGroupEntity.kt
@@ -1,7 +1,7 @@
 package com.dobby.backend.infrastructure.database.entity.experiment
 
 import com.dobby.backend.domain.model.experiment.TargetGroup
-import com.dobby.backend.infrastructure.database.entity.enums.GenderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.GenderType
 import jakarta.persistence.*
 
 @Entity(name = "target_group")

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/member/MemberEntity.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/member/MemberEntity.kt
@@ -58,7 +58,8 @@ class MemberEntity(
         status = status,
         role = role,
         createdAt = createdAt,
-        updatedAt = updatedAt
+        updatedAt = updatedAt,
+        deletedAt = deletedAt
     )
 
     companion object {
@@ -73,7 +74,7 @@ class MemberEntity(
                 name = name,
                 createdAt = createdAt,
                 updatedAt = updatedAt,
-                deletedAt = null
+                deletedAt = deletedAt
             )
         }
     }

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/member/MemberEntity.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/member/MemberEntity.kt
@@ -1,9 +1,9 @@
 package com.dobby.backend.infrastructure.database.entity.member
 
 import com.dobby.backend.domain.model.member.Member
-import com.dobby.backend.infrastructure.database.entity.enums.MemberStatus
-import com.dobby.backend.infrastructure.database.entity.enums.ProviderType
-import com.dobby.backend.infrastructure.database.entity.enums.RoleType
+import com.dobby.backend.infrastructure.database.entity.enums.member.MemberStatus
+import com.dobby.backend.infrastructure.database.entity.enums.member.ProviderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.RoleType
 import com.dobby.backend.infrastructure.database.entity.experiment.ExperimentPostEntity
 import jakarta.persistence.*
 import java.time.LocalDateTime
@@ -43,7 +43,10 @@ class MemberEntity(
     val createdAt: LocalDateTime,
 
     @Column(name = "updated_at", nullable = false)
-    val updatedAt: LocalDateTime
+    val updatedAt: LocalDateTime,
+
+    @Column(name = "deleted_at")
+    val deletedAt: LocalDateTime?
 ) {
 
     fun toDomain() = Member(
@@ -69,7 +72,8 @@ class MemberEntity(
                 contactEmail = contactEmail,
                 name = name,
                 createdAt = createdAt,
-                updatedAt = updatedAt
+                updatedAt = updatedAt,
+                deletedAt = null
             )
         }
     }

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/member/MemberWithdrawalEntity.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/member/MemberWithdrawalEntity.kt
@@ -1,0 +1,42 @@
+package com.dobby.backend.infrastructure.database.entity.member
+
+import com.dobby.backend.domain.model.member.MemberWithdrawal
+import com.dobby.backend.infrastructure.database.entity.enums.member.WithdrawalReasonType
+import jakarta.persistence.*
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "member_withdrawal")
+class MemberWithdrawalEntity(
+    @Id
+    @Column(name = "member_id", columnDefinition = "CHAR(13)")
+    val memberId: String,
+
+    @Column(name = "reason_type", nullable = false)
+    @Enumerated(EnumType.STRING)
+    val reasonType: WithdrawalReasonType,
+
+    @Column(name = "other_reason", nullable = true)
+    val otherReason: String? = null,
+
+    @Column(name = "withdrawn_at", nullable = false)
+    val createdAt: LocalDateTime
+) {
+    fun toDomain() = MemberWithdrawal(
+        memberId = memberId,
+        reasonType = reasonType,
+        otherReason = otherReason,
+        createdAt = createdAt
+    )
+
+    companion object {
+        fun fromDomain(withdrawal: MemberWithdrawal) = with(withdrawal) {
+            MemberWithdrawalEntity(
+                memberId = memberId,
+                reasonType = reasonType,
+                otherReason = otherReason,
+                createdAt = createdAt
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/member/MemberWithdrawalEntity.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/member/MemberWithdrawalEntity.kt
@@ -19,7 +19,7 @@ class MemberWithdrawalEntity(
     @Column(name = "other_reason", nullable = true)
     val otherReason: String? = null,
 
-    @Column(name = "withdrawn_at", nullable = false)
+    @Column(name = "created_at", nullable = false)
     val createdAt: LocalDateTime
 ) {
     fun toDomain() = MemberWithdrawal(

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/member/ParticipantEntity.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/entity/member/ParticipantEntity.kt
@@ -1,6 +1,6 @@
 package com.dobby.backend.infrastructure.database.entity.member
 
-import com.dobby.backend.infrastructure.database.entity.enums.GenderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.GenderType
 import com.dobby.backend.infrastructure.database.entity.enums.MatchType
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Area
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/repository/ExperimentPostCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/repository/ExperimentPostCustomRepositoryImpl.kt
@@ -2,7 +2,7 @@ package com.dobby.backend.infrastructure.database.repository
 
 import com.dobby.backend.application.model.Pagination
 import com.dobby.backend.domain.model.experiment.*
-import com.dobby.backend.infrastructure.database.entity.enums.GenderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.GenderType
 import com.dobby.backend.infrastructure.database.entity.enums.MatchType
 import com.dobby.backend.infrastructure.database.entity.enums.MatchType.*
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Area

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/repository/MemberRepository.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/repository/MemberRepository.kt
@@ -1,7 +1,7 @@
 package com.dobby.backend.infrastructure.database.repository
 
 import com.dobby.backend.infrastructure.database.entity.member.MemberEntity
-import com.dobby.backend.infrastructure.database.entity.enums.MemberStatus
+import com.dobby.backend.infrastructure.database.entity.enums.member.MemberStatus
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface MemberRepository : JpaRepository<MemberEntity, String> {

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/repository/MemberRepository.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/repository/MemberRepository.kt
@@ -2,7 +2,10 @@ package com.dobby.backend.infrastructure.database.repository
 
 import com.dobby.backend.infrastructure.database.entity.member.MemberEntity
 import com.dobby.backend.infrastructure.database.entity.enums.member.MemberStatus
+import com.dobby.backend.infrastructure.database.entity.enums.member.RoleType
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 interface MemberRepository : JpaRepository<MemberEntity, String> {
     fun findByOauthEmail(oauthEmail: String): MemberEntity?
@@ -10,4 +13,7 @@ interface MemberRepository : JpaRepository<MemberEntity, String> {
     fun existsByContactEmail(contactEmail: String): Boolean
     fun findContactEmailById(memberId: String): String
     fun findByContactEmail(contactEmail: String): MemberEntity?
+    @Query("SELECT m.role FROM MemberEntity m WHERE m.id = :memberId AND m.deletedAt IS NULL")
+    fun findRoleByIdAndDeletedAtIsNull(@Param("memberId") memberId: String): RoleType?
+    fun findByIdAndDeletedAtIsNull(memberId: String): MemberEntity?
 }

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/repository/MemberWithdrawalRepository.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/repository/MemberWithdrawalRepository.kt
@@ -1,0 +1,7 @@
+package com.dobby.backend.infrastructure.database.repository
+
+import com.dobby.backend.infrastructure.database.entity.member.MemberWithdrawalEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface MemberWithdrawalRepository: JpaRepository<MemberWithdrawalEntity, String> {
+}

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/repository/ResearcherRepository.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/repository/ResearcherRepository.kt
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface ResearcherRepository: JpaRepository<ResearcherEntity, String> {
     fun findByMemberId(memberId: String) : ResearcherEntity?
+    fun findByMemberIdAndMemberDeletedAtIsNull(memberId: String): ResearcherEntity?
 }

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/repository/VerificationRepository.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/repository/VerificationRepository.kt
@@ -26,4 +26,5 @@ interface VerificationRepository : JpaRepository<VerificationEntity, String> {
         nativeQuery = true
     )
     fun updateCode(univEmail: String, code: String)
+    fun deleteByUnivEmail(univEmail: String)
 }

--- a/src/main/kotlin/com/dobby/backend/infrastructure/gateway/email/VerificationGatewayImpl.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/gateway/email/VerificationGatewayImpl.kt
@@ -35,8 +35,12 @@ class VerificationGatewayImpl(
         return savedEntity.toDomain()
     }
 
-    override fun updateCode(univEmail: String, code: String){
+    override fun updateCode(univEmail: String, code: String) {
         verificationRepository.updateCode(univEmail, code)
         verificationRepository.flush()
+    }
+
+    override fun deleteByUnivEmail(univEmail: String) {
+        verificationRepository.deleteByUnivEmail(univEmail)
     }
 }

--- a/src/main/kotlin/com/dobby/backend/infrastructure/gateway/member/MemberGatewayImpl.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/gateway/member/MemberGatewayImpl.kt
@@ -3,6 +3,7 @@ package com.dobby.backend.infrastructure.gateway.member
 import com.dobby.backend.domain.gateway.member.MemberGateway
 import com.dobby.backend.infrastructure.database.entity.enums.member.MemberStatus
 import com.dobby.backend.domain.model.member.Member
+import com.dobby.backend.infrastructure.database.entity.enums.member.RoleType
 import com.dobby.backend.infrastructure.database.entity.member.MemberEntity
 import com.dobby.backend.infrastructure.database.repository.MemberRepository
 import org.springframework.stereotype.Component
@@ -19,9 +20,8 @@ class MemberGatewayImpl(
 
     override fun findByIdAndDeletedAtIsNull(memberId: String): Member? {
         return memberRepository
-            .findById(memberId)
-            .map(MemberEntity::toDomain)
-            .orElse(null)
+            .findByIdAndDeletedAtIsNull(memberId)
+            ?.let(MemberEntity::toDomain)
     }
 
     override fun findByOauthEmailAndStatus(email: String, status: MemberStatus): Member? {
@@ -54,5 +54,9 @@ class MemberGatewayImpl(
         return memberRepository
             .findByContactEmail(contactEmail)
             ?.let(MemberEntity::toDomain)
+    }
+
+    override fun findRoleByIdAndDeletedAtIsNull(memberId: String): RoleType? {
+        return memberRepository.findRoleByIdAndDeletedAtIsNull(memberId)
     }
 }

--- a/src/main/kotlin/com/dobby/backend/infrastructure/gateway/member/MemberGatewayImpl.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/gateway/member/MemberGatewayImpl.kt
@@ -1,7 +1,7 @@
 package com.dobby.backend.infrastructure.gateway.member
 
 import com.dobby.backend.domain.gateway.member.MemberGateway
-import com.dobby.backend.infrastructure.database.entity.enums.MemberStatus
+import com.dobby.backend.infrastructure.database.entity.enums.member.MemberStatus
 import com.dobby.backend.domain.model.member.Member
 import com.dobby.backend.infrastructure.database.entity.member.MemberEntity
 import com.dobby.backend.infrastructure.database.repository.MemberRepository

--- a/src/main/kotlin/com/dobby/backend/infrastructure/gateway/member/MemberGatewayImpl.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/gateway/member/MemberGatewayImpl.kt
@@ -17,7 +17,7 @@ class MemberGatewayImpl(
             .let(MemberEntity::toDomain)
     }
 
-    override fun findById(memberId: String): Member? {
+    override fun findByIdAndDeletedAtIsNull(memberId: String): Member? {
         return memberRepository
             .findById(memberId)
             .map(MemberEntity::toDomain)

--- a/src/main/kotlin/com/dobby/backend/infrastructure/gateway/member/MemberWithdrawalGatewayImpl.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/gateway/member/MemberWithdrawalGatewayImpl.kt
@@ -1,0 +1,18 @@
+package com.dobby.backend.infrastructure.gateway.member
+
+import com.dobby.backend.domain.gateway.member.MemberWithdrawalGateway
+import com.dobby.backend.domain.model.member.MemberWithdrawal
+import com.dobby.backend.infrastructure.database.entity.member.MemberWithdrawalEntity
+import com.dobby.backend.infrastructure.database.repository.MemberWithdrawalRepository
+import org.springframework.stereotype.Component
+
+@Component
+class MemberWithdrawalGatewayImpl(
+    private val memberWithdrawalRepository: MemberWithdrawalRepository
+) : MemberWithdrawalGateway {
+    override fun save(memberWithdrawal: MemberWithdrawal): MemberWithdrawal {
+        val savedEntity = memberWithdrawalRepository
+            .save(MemberWithdrawalEntity.fromDomain(memberWithdrawal))
+        return savedEntity.toDomain()
+    }
+}

--- a/src/main/kotlin/com/dobby/backend/infrastructure/gateway/member/ResearcherGatewayImpl.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/gateway/member/ResearcherGatewayImpl.kt
@@ -17,6 +17,12 @@ class ResearcherGatewayImpl(
             ?.let(ResearcherEntity::toDomain)
     }
 
+    override fun findByMemberIdAndMemberDeletedAtIsNull(memberId: String): Researcher? {
+        return researcherRepository
+            .findByMemberIdAndMemberDeletedAtIsNull(memberId)
+            ?.let(ResearcherEntity::toDomain)
+    }
+
     override fun save(researcher: Researcher): Researcher {
         val savedEntity = researcherRepository
             .save(ResearcherEntity.fromDomain(researcher))

--- a/src/main/kotlin/com/dobby/backend/presentation/api/controller/AuthController.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/controller/AuthController.kt
@@ -2,7 +2,7 @@ package com.dobby.backend.presentation.api.controller
 
 import com.dobby.backend.application.service.AuthService
 import com.dobby.backend.presentation.api.dto.response.auth.OauthLoginResponse
-import com.dobby.backend.infrastructure.database.entity.enums.RoleType
+import com.dobby.backend.infrastructure.database.entity.enums.member.RoleType
 import com.dobby.backend.presentation.api.dto.request.auth.GoogleOauthLoginRequest
 import com.dobby.backend.presentation.api.dto.request.auth.MemberRefreshTokenRequest
 import com.dobby.backend.presentation.api.dto.request.auth.NaverOauthLoginRequest

--- a/src/main/kotlin/com/dobby/backend/presentation/api/controller/EmailController.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/controller/EmailController.kt
@@ -43,5 +43,4 @@ class EmailController(
         val output = emailService.verifyCode(input)
         return EmailMapper.toEmailVerificationResponse(output)
     }
-
 }

--- a/src/main/kotlin/com/dobby/backend/presentation/api/controller/ExperimentPostController.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/controller/ExperimentPostController.kt
@@ -3,7 +3,7 @@ package com.dobby.backend.presentation.api.controller
 import com.dobby.backend.application.service.ExperimentPostService
 import com.dobby.backend.presentation.api.dto.request.PreSignedUrlRequest
 import com.dobby.backend.presentation.api.dto.response.PreSignedUrlResponse
-import com.dobby.backend.infrastructure.database.entity.enums.GenderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.GenderType
 import com.dobby.backend.infrastructure.database.entity.enums.MatchType
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Area
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region

--- a/src/main/kotlin/com/dobby/backend/presentation/api/controller/MemberController.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/controller/MemberController.kt
@@ -11,6 +11,7 @@ import com.dobby.backend.presentation.api.dto.response.member.ParticipantInfoRes
 import com.dobby.backend.presentation.api.dto.response.member.ResearcherInfoResponse
 import com.dobby.backend.presentation.api.dto.response.member.SignupResponse
 import com.dobby.backend.presentation.api.mapper.MemberMapper
+import com.dobby.backend.util.getCurrentMemberId
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
@@ -138,8 +139,11 @@ class MemberController(
     fun deleteMember(
         @RequestBody @Valid request: DeleteMemberRequest
     ): DefaultResponse {
-        val input = MemberMapper.toDeleteMemberUseCaseInput(request)
-        val output = memberService.deleteMember(input)
-        return DefaultResponse(output.isSuccess)
+        val memberId = getCurrentMemberId()
+        val roleType = memberService.getMemberRole(memberId)
+
+        val input = MemberMapper.toDeleteMemberUseCaseInput(request, roleType)
+        memberService.deleteMember(input)
+        return DefaultResponse(true)
     }
 }

--- a/src/main/kotlin/com/dobby/backend/presentation/api/controller/MemberController.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/controller/MemberController.kt
@@ -129,4 +129,17 @@ class MemberController(
         val output = memberService.validateContactEmailForUpdate(input)
         return DefaultResponse(output.isDuplicate)
     }
+
+    @DeleteMapping
+    @Operation(
+        summary = "회원 탈퇴 API",
+        description = "회원 탈퇴 API입니다."
+    )
+    fun deleteMember(
+        @RequestBody @Valid request: DeleteMemberRequest
+    ): DefaultResponse {
+        val input = MemberMapper.toDeleteMemberUseCaseInput(request)
+        val output = memberService.deleteMember(input)
+        return DefaultResponse(output.isSuccess)
+    }
 }

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/experiment/CreateExperimentPostRequest.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/experiment/CreateExperimentPostRequest.kt
@@ -1,7 +1,7 @@
 package com.dobby.backend.presentation.api.dto.request.experiment
 
 import com.dobby.backend.infrastructure.database.entity.enums.MatchType
-import com.dobby.backend.infrastructure.database.entity.enums.TimeSlot
+import com.dobby.backend.infrastructure.database.entity.enums.experiment.TimeSlot
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Area
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region
 import java.time.LocalDate

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/experiment/RelationInfo.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/experiment/RelationInfo.kt
@@ -1,6 +1,6 @@
 package com.dobby.backend.presentation.api.dto.request.experiment
 
-import com.dobby.backend.infrastructure.database.entity.enums.GenderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.GenderType
 
 data class RelationInfo (
     val targetGroupInfo: TargetGroupInfo,

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/experiment/UpdateExperimentPostRequest.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/experiment/UpdateExperimentPostRequest.kt
@@ -1,7 +1,7 @@
 package com.dobby.backend.presentation.api.dto.request.experiment
 
 import com.dobby.backend.infrastructure.database.entity.enums.MatchType
-import com.dobby.backend.infrastructure.database.entity.enums.TimeSlot
+import com.dobby.backend.infrastructure.database.entity.enums.experiment.TimeSlot
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Area
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region
 import java.time.LocalDate

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/member/DeleteMemberRequest.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/member/DeleteMemberRequest.kt
@@ -1,0 +1,14 @@
+package com.dobby.backend.presentation.api.dto.request.member
+
+import com.dobby.backend.infrastructure.database.entity.enums.member.WithdrawalReasonType
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotNull
+
+data class DeleteMemberRequest (
+    @NotNull(message = "탈퇴 사유 타입은 공백일 수 없습니다.")
+    @Schema(description = "탈퇴 사유 타입")
+    val reasonType: WithdrawalReasonType,
+
+    @Schema(description = "기타 탈퇴 사유")
+    val reason: String?
+)

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/member/ParticipantSignupRequest.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/member/ParticipantSignupRequest.kt
@@ -1,8 +1,8 @@
 package com.dobby.backend.presentation.api.dto.request.member
 
-import com.dobby.backend.infrastructure.database.entity.enums.GenderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.GenderType
 import com.dobby.backend.infrastructure.database.entity.enums.MatchType
-import com.dobby.backend.infrastructure.database.entity.enums.ProviderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.ProviderType
 import com.dobby.backend.presentation.api.dto.response.member.AddressInfoResponse
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Email

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/member/ResearcherSignupRequest.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/request/member/ResearcherSignupRequest.kt
@@ -1,6 +1,6 @@
 package com.dobby.backend.presentation.api.dto.request.member
 
-import com.dobby.backend.infrastructure.database.entity.enums.ProviderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.ProviderType
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/experiment/ExperimentPostDetailResponse.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/experiment/ExperimentPostDetailResponse.kt
@@ -5,6 +5,7 @@ import com.dobby.backend.infrastructure.database.entity.enums.MatchType
 import com.dobby.backend.infrastructure.database.entity.enums.experiment.TimeSlot
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Area
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region
+import com.dobby.backend.infrastructure.database.entity.enums.member.MemberStatus
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 
@@ -21,6 +22,9 @@ data class ExperimentPostDetailResponse(
 
     @Schema(description = "업로더 이름", example = "야뿌")
     val uploaderName: String,
+
+    @Schema(description = "업로더 활성 상태", example = true.toString())
+    val isUploaderActive: Boolean,
 
     @Schema(description = "조회수", example = "123")
     val views: Int,

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/experiment/ExperimentPostDetailResponse.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/experiment/ExperimentPostDetailResponse.kt
@@ -1,8 +1,8 @@
 package com.dobby.backend.presentation.api.dto.response.experiment
 
-import com.dobby.backend.infrastructure.database.entity.enums.GenderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.GenderType
 import com.dobby.backend.infrastructure.database.entity.enums.MatchType
-import com.dobby.backend.infrastructure.database.entity.enums.TimeSlot
+import com.dobby.backend.infrastructure.database.entity.enums.experiment.TimeSlot
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Area
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region
 import io.swagger.v3.oas.annotations.media.Schema

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/member/MemberResponse.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/member/MemberResponse.kt
@@ -1,8 +1,8 @@
 package com.dobby.backend.presentation.api.dto.response.member
 
 import com.dobby.backend.domain.model.member.Member
-import com.dobby.backend.infrastructure.database.entity.enums.ProviderType
-import com.dobby.backend.infrastructure.database.entity.enums.RoleType
+import com.dobby.backend.infrastructure.database.entity.enums.member.ProviderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.RoleType
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "사용자 DTO")

--- a/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/member/ParticipantInfoResponse.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/dto/response/member/ParticipantInfoResponse.kt
@@ -1,6 +1,6 @@
 package com.dobby.backend.presentation.api.dto.response.member
 
-import com.dobby.backend.infrastructure.database.entity.enums.GenderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.GenderType
 import com.dobby.backend.infrastructure.database.entity.enums.MatchType
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate

--- a/src/main/kotlin/com/dobby/backend/presentation/api/mapper/AuthMapper.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/mapper/AuthMapper.kt
@@ -4,7 +4,7 @@ import com.dobby.backend.application.usecase.auth.FetchGoogleUserInfoUseCase
 import com.dobby.backend.application.usecase.auth.FetchNaverUserInfoUseCase
 import com.dobby.backend.application.usecase.auth.GenerateTestTokenUseCase
 import com.dobby.backend.application.usecase.auth.GenerateTokenWithRefreshTokenUseCase
-import com.dobby.backend.infrastructure.database.entity.enums.RoleType
+import com.dobby.backend.infrastructure.database.entity.enums.member.RoleType
 import com.dobby.backend.presentation.api.dto.response.auth.OauthLoginResponse
 import com.dobby.backend.presentation.api.dto.response.auth.TestMemberSignInResponse
 import com.dobby.backend.presentation.api.dto.response.member.MemberResponse

--- a/src/main/kotlin/com/dobby/backend/presentation/api/mapper/ExperimentPostMapper.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/mapper/ExperimentPostMapper.kt
@@ -6,7 +6,7 @@ import com.dobby.backend.application.usecase.experiment.GetExperimentPostApplyMe
 import com.dobby.backend.application.usecase.experiment.GetExperimentPostDetailUseCase
 import com.dobby.backend.presentation.api.dto.request.PreSignedUrlRequest
 import com.dobby.backend.presentation.api.dto.response.PreSignedUrlResponse
-import com.dobby.backend.infrastructure.database.entity.enums.GenderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.GenderType
 import com.dobby.backend.infrastructure.database.entity.enums.MatchType
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Area
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region

--- a/src/main/kotlin/com/dobby/backend/presentation/api/mapper/ExperimentPostMapper.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/mapper/ExperimentPostMapper.kt
@@ -176,7 +176,8 @@ object ExperimentPostMapper {
             address = response.experimentPostDetailResponse.address,
             content = response.experimentPostDetailResponse.content,
             imageList = response.experimentPostDetailResponse.imageList,
-            isAuthor = response.experimentPostDetailResponse.isAuthor
+            isAuthor = response.experimentPostDetailResponse.isAuthor,
+            isUploaderActive = response.experimentPostDetailResponse.isUploaderActive
         )
     }
 

--- a/src/main/kotlin/com/dobby/backend/presentation/api/mapper/MemberMapper.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/mapper/MemberMapper.kt
@@ -4,6 +4,7 @@ import com.dobby.backend.application.usecase.member.*
 import com.dobby.backend.domain.model.member.Participant
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Area
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region
+import com.dobby.backend.infrastructure.database.entity.enums.member.RoleType
 import com.dobby.backend.presentation.api.dto.request.member.*
 import com.dobby.backend.presentation.api.dto.response.member.*
 import com.dobby.backend.util.getCurrentMemberId
@@ -185,11 +186,18 @@ object MemberMapper {
         )
     }
 
-    fun toDeleteMemberUseCaseInput(request: DeleteMemberRequest): DeleteMemberUseCase.Input {
-        return DeleteMemberUseCase.Input(
-            memberId = getCurrentMemberId(),
-            reasonType = request.reasonType,
-            reason = request.reason
-        )
+    fun toDeleteMemberUseCaseInput(request: DeleteMemberRequest, roleType: RoleType): Any {
+        return when (roleType) {
+            RoleType.RESEARCHER -> DeleteResearcherUseCase.Input(
+                memberId = getCurrentMemberId(),
+                reasonType = request.reasonType,
+                reason = request.reason
+            )
+            RoleType.PARTICIPANT -> DeleteParticipantUseCase.Input(
+                memberId = getCurrentMemberId(),
+                reasonType = request.reasonType,
+                reason = request.reason
+            )
+        }
     }
 }

--- a/src/main/kotlin/com/dobby/backend/presentation/api/mapper/MemberMapper.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/mapper/MemberMapper.kt
@@ -184,4 +184,12 @@ object MemberMapper {
             contactEmail = email
         )
     }
+
+    fun toDeleteMemberUseCaseInput(request: DeleteMemberRequest): DeleteMemberUseCase.Input {
+        return DeleteMemberUseCase.Input(
+            memberId = getCurrentMemberId(),
+            reasonType = request.reasonType,
+            reason = request.reason
+        )
+    }
 }

--- a/src/test/kotlin/com/dobby/backend/application/usecase/auth/FetchGoogleUserInfoUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/auth/FetchGoogleUserInfoUseCaseTest.kt
@@ -38,7 +38,8 @@ class FetchGoogleUserInfoUseCaseTest : BehaviorSpec({
             contactEmail = "contact@example.com",
             provider = ProviderType.GOOGLE,
             createdAt = LocalDateTime.now(),
-            updatedAt = LocalDateTime.now()
+            updatedAt = LocalDateTime.now(),
+            deletedAt = null
         )
 
         val mockEmptyMember = null

--- a/src/test/kotlin/com/dobby/backend/application/usecase/auth/FetchGoogleUserInfoUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/auth/FetchGoogleUserInfoUseCaseTest.kt
@@ -4,9 +4,9 @@ import com.dobby.backend.domain.gateway.member.MemberGateway
 import com.dobby.backend.domain.gateway.auth.TokenGateway
 import com.dobby.backend.domain.gateway.auth.GoogleAuthGateway
 import com.dobby.backend.domain.model.member.Member
-import com.dobby.backend.infrastructure.database.entity.enums.MemberStatus
-import com.dobby.backend.infrastructure.database.entity.enums.ProviderType
-import com.dobby.backend.infrastructure.database.entity.enums.RoleType
+import com.dobby.backend.infrastructure.database.entity.enums.member.MemberStatus
+import com.dobby.backend.infrastructure.database.entity.enums.member.ProviderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.RoleType
 import com.dobby.backend.presentation.api.dto.response.auth.google.GoogleTokenResponse
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe

--- a/src/test/kotlin/com/dobby/backend/application/usecase/auth/FetchNaverUserInfoUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/auth/FetchNaverUserInfoUseCaseTest.kt
@@ -39,7 +39,8 @@ class FetchNaverUserInfoUseCaseTest : BehaviorSpec({
             contactEmail = "contact@example.com",
             provider = ProviderType.NAVER,
             createdAt = LocalDateTime.now(),
-            updatedAt = LocalDateTime.now()
+            updatedAt = LocalDateTime.now(),
+            deletedAt = null
         )
 
         val mockEmptyMember = null

--- a/src/test/kotlin/com/dobby/backend/application/usecase/auth/FetchNaverUserInfoUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/auth/FetchNaverUserInfoUseCaseTest.kt
@@ -4,9 +4,9 @@ import com.dobby.backend.domain.gateway.member.MemberGateway
 import com.dobby.backend.domain.gateway.auth.NaverAuthGateway
 import com.dobby.backend.domain.gateway.auth.TokenGateway
 import com.dobby.backend.domain.model.member.Member
-import com.dobby.backend.infrastructure.database.entity.enums.MemberStatus
-import com.dobby.backend.infrastructure.database.entity.enums.ProviderType
-import com.dobby.backend.infrastructure.database.entity.enums.RoleType
+import com.dobby.backend.infrastructure.database.entity.enums.member.MemberStatus
+import com.dobby.backend.infrastructure.database.entity.enums.member.ProviderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.RoleType
 import com.dobby.backend.presentation.api.dto.response.auth.naver.NaverTokenResponse
 import com.dobby.backend.presentation.api.dto.response.auth.naver.NaverUserResponse
 import io.kotest.core.spec.style.BehaviorSpec

--- a/src/test/kotlin/com/dobby/backend/application/usecase/auth/GenerateTestTokenUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/auth/GenerateTestTokenUseCaseTest.kt
@@ -22,7 +22,7 @@ class GenerateTestTokenUseCaseTest: BehaviorSpec({
     given("memberId가 주어졌을 때") {
         val member = Member(id = "1", oauthEmail = "dlawotn3@naver.com", contactEmail = "dlawotn3@naver.com",
             provider = ProviderType.NAVER, role = RoleType.PARTICIPANT, name = "dobby",
-            status = MemberStatus.ACTIVE, createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now())
+            status = MemberStatus.ACTIVE, createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now(), deletedAt = null)
         val accessToken = "testAccessToken"
         val refreshToken = "testRefreshToken"
 

--- a/src/test/kotlin/com/dobby/backend/application/usecase/auth/GenerateTestTokenUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/auth/GenerateTestTokenUseCaseTest.kt
@@ -28,7 +28,7 @@ class GenerateTestTokenUseCaseTest: BehaviorSpec({
 
         every { tokenGateway.generateAccessToken(member) } returns accessToken
         every { tokenGateway.generateRefreshToken(member) } returns refreshToken
-        every { memberGateway.findById("1") } returns member
+        every { memberGateway.findByIdAndDeletedAtIsNull("1") } returns member
 
         `when`("execute가 호출되면") {
             val input = GenerateTestTokenUseCase.Input(member.id)
@@ -40,7 +40,7 @@ class GenerateTestTokenUseCaseTest: BehaviorSpec({
             }
         }
 
-        every { memberGateway.findById("2") } returns null
+        every { memberGateway.findByIdAndDeletedAtIsNull("2") } returns null
 
         `when`("존재하지 않는 회원 ID가 주어졌을 때") {
             val input = GenerateTestTokenUseCase.Input("2")

--- a/src/test/kotlin/com/dobby/backend/application/usecase/auth/GenerateTestTokenUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/auth/GenerateTestTokenUseCaseTest.kt
@@ -5,9 +5,9 @@ import com.dobby.backend.domain.gateway.member.MemberGateway
 import io.kotest.core.spec.style.BehaviorSpec
 import com.dobby.backend.domain.gateway.auth.TokenGateway
 import com.dobby.backend.domain.model.member.Member
-import com.dobby.backend.infrastructure.database.entity.enums.MemberStatus
-import com.dobby.backend.infrastructure.database.entity.enums.ProviderType
-import com.dobby.backend.infrastructure.database.entity.enums.RoleType
+import com.dobby.backend.infrastructure.database.entity.enums.member.MemberStatus
+import com.dobby.backend.infrastructure.database.entity.enums.member.ProviderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.RoleType
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.mockk.every

--- a/src/test/kotlin/com/dobby/backend/application/usecase/auth/GenerateTokenWithRefreshTokenUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/auth/GenerateTokenWithRefreshTokenUseCaseTest.kt
@@ -21,7 +21,7 @@ class GenerateTokenWithRefreshTokenUseCaseTest : BehaviorSpec({
         val validRefreshToken = "validRefreshToken"
         val member = Member(id = "1", oauthEmail = "dlawotn3@naver.com", contactEmail = "dlawotn3@naver.com",
             provider = ProviderType.NAVER, role = RoleType.PARTICIPANT, name = "dobby",
-            status = MemberStatus.ACTIVE, createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now())
+            status = MemberStatus.ACTIVE, createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now(), deletedAt = null)
         val accessToken = "newAccessToken"
         val newRefreshToken = "newRefreshToken"
 

--- a/src/test/kotlin/com/dobby/backend/application/usecase/auth/GenerateTokenWithRefreshTokenUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/auth/GenerateTokenWithRefreshTokenUseCaseTest.kt
@@ -3,9 +3,9 @@ package com.dobby.backend.application.usecase.auth
 import com.dobby.backend.domain.gateway.member.MemberGateway
 import com.dobby.backend.domain.gateway.auth.TokenGateway
 import com.dobby.backend.domain.model.member.Member
-import com.dobby.backend.infrastructure.database.entity.enums.MemberStatus
-import com.dobby.backend.infrastructure.database.entity.enums.ProviderType
-import com.dobby.backend.infrastructure.database.entity.enums.RoleType
+import com.dobby.backend.infrastructure.database.entity.enums.member.MemberStatus
+import com.dobby.backend.infrastructure.database.entity.enums.member.ProviderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.RoleType
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every

--- a/src/test/kotlin/com/dobby/backend/application/usecase/experiment/CreateExperimentPostUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/experiment/CreateExperimentPostUseCaseTest.kt
@@ -41,7 +41,8 @@ class CreateExperimentPostUseCaseTest: BehaviorSpec ({
             provider = ProviderType.NAVER,
             status = MemberStatus.ACTIVE,
             createdAt = LocalDateTime.now(),
-            updatedAt = LocalDateTime.now()
+            updatedAt = LocalDateTime.now(),
+            deletedAt = null
         )
 
         val validInput = CreateExperimentPostUseCase.Input(
@@ -102,7 +103,8 @@ class CreateExperimentPostUseCaseTest: BehaviorSpec ({
             provider = ProviderType.NAVER,
             status = MemberStatus.ACTIVE,
             createdAt = LocalDateTime.now(),
-            updatedAt = LocalDateTime.now()
+            updatedAt = LocalDateTime.now(),
+            deletedAt = null
         )
 
         val invalidInput = CreateExperimentPostUseCase.Input(
@@ -155,7 +157,8 @@ class CreateExperimentPostUseCaseTest: BehaviorSpec ({
             provider = ProviderType.NAVER,
             status = MemberStatus.ACTIVE,
             createdAt = LocalDateTime.now(),
-            updatedAt = LocalDateTime.now()
+            updatedAt = LocalDateTime.now(),
+            deletedAt = null
         )
 
         val invalidInput = CreateExperimentPostUseCase.Input(
@@ -210,7 +213,8 @@ class CreateExperimentPostUseCaseTest: BehaviorSpec ({
             provider = ProviderType.NAVER,
             status = MemberStatus.ACTIVE,
             createdAt = LocalDateTime.now(),
-            updatedAt = LocalDateTime.now()
+            updatedAt = LocalDateTime.now(),
+            deletedAt = null
         )
 
         val invalidInput = CreateExperimentPostUseCase.Input(

--- a/src/test/kotlin/com/dobby/backend/application/usecase/experiment/CreateExperimentPostUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/experiment/CreateExperimentPostUseCaseTest.kt
@@ -11,6 +11,11 @@ import com.dobby.backend.domain.model.member.Member
 import com.dobby.backend.infrastructure.database.entity.enums.*
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Area
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region
+import com.dobby.backend.infrastructure.database.entity.enums.experiment.TimeSlot
+import com.dobby.backend.infrastructure.database.entity.enums.member.GenderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.MemberStatus
+import com.dobby.backend.infrastructure.database.entity.enums.member.ProviderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.RoleType
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe

--- a/src/test/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostApplyMethodUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostApplyMethodUseCaseTest.kt
@@ -7,7 +7,7 @@ import com.dobby.backend.domain.model.experiment.ExperimentPost
 import com.dobby.backend.domain.model.experiment.TargetGroup
 import com.dobby.backend.domain.model.member.Member
 import com.dobby.backend.infrastructure.database.entity.enums.MatchType
-import com.dobby.backend.infrastructure.database.entity.enums.TimeSlot
+import com.dobby.backend.infrastructure.database.entity.enums.experiment.TimeSlot
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Area
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region
 import io.kotest.core.spec.style.BehaviorSpec

--- a/src/test/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostDetailUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostDetailUseCaseTest.kt
@@ -7,44 +7,53 @@ import com.dobby.backend.domain.model.experiment.ExperimentPost
 import com.dobby.backend.domain.model.experiment.TargetGroup
 import com.dobby.backend.domain.model.member.Member
 import com.dobby.backend.infrastructure.database.entity.enums.MatchType
-import com.dobby.backend.infrastructure.database.entity.enums.experiment.TimeSlot
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Area
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region
+import com.dobby.backend.infrastructure.database.entity.enums.experiment.TimeSlot
+import com.dobby.backend.infrastructure.database.entity.enums.member.*
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import java.time.LocalDate
 import java.time.LocalDateTime
-import com.dobby.backend.infrastructure.database.entity.enums.member.GenderType
 
 class GetExperimentPostDetailUseCaseTest : BehaviorSpec({
     val experimentPostGateway = mockk<ExperimentPostGateway>()
     val getExperimentPostDetailUseCase = GetExperimentPostDetailUseCase(experimentPostGateway)
 
-    given("유효한 experimentPostId가 주어졌을 때") {
+    val targetGroup = mockk<TargetGroup>().apply {
+        every { id } returns "tg-1"
+        every { startAge } returns 18
+        every { endAge } returns 30
+        every { genderType } returns GenderType.ALL
+        every { otherCondition } returns "특별한 조건 없음"
+    }
+    val applyMethod = mockk<ApplyMethod>().apply {
+        every { id } returns "am-1"
+        every { phoneNum } returns "010-1234-5678"
+        every { formUrl } returns "http://apply.com/form"
+        every { content } returns "지원 방법 상세 설명"
+    }
+
+    given("유효한 experimentPostId가 주어졌을 때 (작성자 활성 상태)") {
         val experimentPostId = "1"
-
-        val member = mockk<Member>()
-        every { member.name } returns "임도비"
-        every { member.id } returns "1"
-
-        val targetGroup = mockk<TargetGroup>()
-        every { targetGroup.id } returns "1"
-        every { targetGroup.startAge } returns 18
-        every { targetGroup.endAge } returns 30
-        every { targetGroup.genderType } returns GenderType.ALL
-        every { targetGroup.otherCondition } returns "특별한 조건 없음"
-
-        val applyMethod = mockk<ApplyMethod>()
-        every { applyMethod.id } returns "1"
-        every { applyMethod.phoneNum } returns "010-1234-5678"
-        every { applyMethod.formUrl } returns "http://apply.com/form"
-        every { applyMethod.content } returns "지원 방법에 대한 상세 설명"
+        val member = Member(
+            id = "1",
+            name = "임도비",
+            oauthEmail = "im@example.com",
+            contactEmail = "im@example.com",
+            provider = ProviderType.NAVER,
+            status = MemberStatus.ACTIVE,
+            role = RoleType.RESEARCHER,
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now(),
+            deletedAt = null
+        )
 
         val experimentPost = ExperimentPost(
             id = experimentPostId,
-            title = "야뿌들의 평균 식사량 체크 테스트",
+            title = "실험 공고 테스트",
             createdAt = LocalDateTime.now(),
             updatedAt = LocalDateTime.now(),
             member = member,
@@ -62,8 +71,8 @@ class GetExperimentPostDetailUseCaseTest : BehaviorSpec({
             region = Region.SEOUL,
             area = Area.GWANGJINGU,
             univName = "건국대학교",
-            detailedAddress = "건국대학교 공학관",
-            content = "야뿌들의 한끼 식사량을 체크하는 테스트입니다.",
+            detailedAddress = "건대입구 123호",
+            content = "실험 공고 내용입니다.",
             alarmAgree = false,
             images = mutableListOf()
         )
@@ -76,18 +85,75 @@ class GetExperimentPostDetailUseCaseTest : BehaviorSpec({
             val initialViews = experimentPost.views
             val result = getExperimentPostDetailUseCase.execute(input)
 
-            then("isAuthor가 true인 experimentPostDetailResponse가 반환된다") {
+            then("isAuthor가 true여야 하고 uploaderStatus는 true여야 한다") {
                 result.experimentPostDetailResponse.title shouldBe experimentPost.title
                 result.experimentPostDetailResponse.isAuthor shouldBe true
+                result.experimentPostDetailResponse.isUploaderActive shouldBe true
             }
 
-            then("views가 증가했는지 확인한다") {
+            then("views가 1 증가했는지 확인한다") {
                 experimentPost.views shouldBe (initialViews + 1)
+            }
+        }
+    }
+
+    given("유효한 experimentPostId가 주어졌을 때 (작성자 탈퇴 상태)") {
+        val experimentPostId = "2"
+        val deletedMember = Member(
+            id = "2",
+            name = "탈퇴회원",
+            oauthEmail = "deleted@example.com",
+            contactEmail = "deleted@example.com",
+            provider = ProviderType.NAVER,
+            status = MemberStatus.HOLD,
+            role = RoleType.RESEARCHER,
+            createdAt = LocalDateTime.now().minusDays(10),
+            updatedAt = LocalDateTime.now().minusDays(5),
+            deletedAt = LocalDateTime.now().minusDays(1)
+        )
+
+        val experimentPost = ExperimentPost(
+            id = experimentPostId,
+            title = "탈퇴 회원 공고",
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now(),
+            member = deletedMember,
+            views = 50,
+            recruitStatus = false,
+            startDate = LocalDate.now(),
+            endDate = LocalDate.now(),
+            leadResearcher = "Lead",
+            matchType = MatchType.ALL,
+            reward = "보상",
+            count = 10,
+            timeRequired = TimeSlot.ABOUT_1H,
+            targetGroup = targetGroup,
+            applyMethod = applyMethod,
+            region = Region.SEOUL,
+            area = Area.GWANGJINGU,
+            univName = "어느대학교",
+            detailedAddress = "어디구 어딘가",
+            content = "탈퇴 회원 공고 내용",
+            alarmAgree = false,
+            images = mutableListOf()
+        )
+
+        every { experimentPostGateway.findById(experimentPostId) } returns experimentPost
+        every { experimentPostGateway.save(experimentPost) } returns experimentPost
+
+        `when`("작성자(업로더)가 탈퇴한 공고를 대상으로 execute가 호출되면") {
+            val input = GetExperimentPostDetailUseCase.Input(experimentPostId = experimentPostId, memberId = deletedMember.id)
+            val result = getExperimentPostDetailUseCase.execute(input)
+
+            then("isAuthor가 true여야 하고 uploaderStatus는 true여야 한다") {
+                result.experimentPostDetailResponse.title shouldBe experimentPost.title
+                result.experimentPostDetailResponse.isAuthor shouldBe true
+                result.experimentPostDetailResponse.isUploaderActive shouldBe false
             }
         }
 
         `when`("다른 사람이 작성한 공고를 대상으로 execute가 호출되면") {
-            val input = GetExperimentPostDetailUseCase.Input(experimentPostId = experimentPostId, memberId = "2")
+            val input = GetExperimentPostDetailUseCase.Input(experimentPostId = experimentPostId, memberId = "3")
             val result = getExperimentPostDetailUseCase.execute(input)
 
             then("isAuthor가 false인 experimentPostDetailResponse가 반환된다") {
@@ -109,7 +175,6 @@ class GetExperimentPostDetailUseCaseTest : BehaviorSpec({
 
     given("유효하지 않은 experimentPostId가 주어졌을 때") {
         val invalidExperimentPostId = "999"
-
         every { experimentPostGateway.findById(invalidExperimentPostId) } returns null
 
         `when`("execute가 호출되면") {

--- a/src/test/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostDetailUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostDetailUseCaseTest.kt
@@ -7,7 +7,7 @@ import com.dobby.backend.domain.model.experiment.ExperimentPost
 import com.dobby.backend.domain.model.experiment.TargetGroup
 import com.dobby.backend.domain.model.member.Member
 import com.dobby.backend.infrastructure.database.entity.enums.MatchType
-import com.dobby.backend.infrastructure.database.entity.enums.TimeSlot
+import com.dobby.backend.infrastructure.database.entity.enums.experiment.TimeSlot
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Area
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region
 import io.kotest.core.spec.style.BehaviorSpec
@@ -16,7 +16,7 @@ import io.mockk.every
 import io.mockk.mockk
 import java.time.LocalDate
 import java.time.LocalDateTime
-import com.dobby.backend.infrastructure.database.entity.enums.GenderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.GenderType
 
 class GetExperimentPostDetailUseCaseTest : BehaviorSpec({
     val experimentPostGateway = mockk<ExperimentPostGateway>()

--- a/src/test/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostDetailUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostDetailUseCaseTest.kt
@@ -106,6 +106,17 @@ class GetExperimentPostDetailUseCaseTest : BehaviorSpec({
                 result.experimentPostDetail.isAuthor shouldBe false
             }
         }
+
+        `when`("탈퇴한 회원이 작성한 게시글인 경우") {
+            every { member.deletedAt } returns LocalDateTime.now()
+            val input = GetExperimentPostDetailUseCase.Input(experimentPostId = experimentPostId, memberId = null)
+            val result = getExperimentPostDetailUseCase.execute(input)
+
+            then("isAuthor가 false인 experimentPostDetail이 반환된다") {
+                result.experimentPostDetail.title shouldBe experimentPost.title
+                result.experimentPostDetail.isAuthor shouldBe false
+            }
+        }
     }
 
     given("유효하지 않은 experimentPostId가 주어졌을 때") {

--- a/src/test/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostsUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostsUseCaseTest.kt
@@ -13,6 +13,11 @@ import com.dobby.backend.infrastructure.database.entity.enums.*
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Area
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region
 import com.dobby.backend.infrastructure.database.entity.enums.experiment.RecruitStatus
+import com.dobby.backend.infrastructure.database.entity.enums.experiment.TimeSlot
+import com.dobby.backend.infrastructure.database.entity.enums.member.GenderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.MemberStatus
+import com.dobby.backend.infrastructure.database.entity.enums.member.ProviderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.RoleType
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every

--- a/src/test/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostsUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostsUseCaseTest.kt
@@ -73,7 +73,8 @@ class GetExperimentPostsUseCaseTest : BehaviorSpec({
                 provider = ProviderType.GOOGLE,
                 status = MemberStatus.ACTIVE,
                 createdAt = LocalDateTime.now(),
-                updatedAt = LocalDateTime.now()
+                updatedAt = LocalDateTime.now(),
+                deletedAt = null
             ),
             targetGroup = TargetGroup(
                 id = "0",
@@ -155,7 +156,8 @@ class GetExperimentPostsUseCaseTest : BehaviorSpec({
                 provider = ProviderType.GOOGLE,
                 status = MemberStatus.ACTIVE,
                 createdAt = LocalDateTime.now(),
-                updatedAt = LocalDateTime.now()
+                updatedAt = LocalDateTime.now(),
+                deletedAt = null
             ),
             targetGroup = TargetGroup(
                 id = "0",
@@ -234,7 +236,8 @@ class GetExperimentPostsUseCaseTest : BehaviorSpec({
                 provider = ProviderType.GOOGLE,
                 status = MemberStatus.ACTIVE,
                 createdAt = LocalDateTime.now(),
-                updatedAt = LocalDateTime.now()
+                updatedAt = LocalDateTime.now(),
+                deletedAt = null
             ),
             targetGroup = TargetGroup(
                 id = "0",
@@ -312,7 +315,8 @@ class GetExperimentPostsUseCaseTest : BehaviorSpec({
                 provider = ProviderType.GOOGLE,
                 status = MemberStatus.ACTIVE,
                 createdAt = LocalDateTime.now(),
-                updatedAt = LocalDateTime.now()
+                updatedAt = LocalDateTime.now(),
+                deletedAt = null
             ),
             targetGroup = TargetGroup(
                 id = "0",
@@ -390,7 +394,8 @@ class GetExperimentPostsUseCaseTest : BehaviorSpec({
                 provider = ProviderType.GOOGLE,
                 status = MemberStatus.ACTIVE,
                 createdAt = LocalDateTime.now(),
-                updatedAt = LocalDateTime.now()
+                updatedAt = LocalDateTime.now(),
+                deletedAt = null
             ),
             targetGroup = TargetGroup(
                 id = "0",

--- a/src/test/kotlin/com/dobby/backend/application/usecase/experiment/GetMyExperimentPostsUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/experiment/GetMyExperimentPostsUseCaseTest.kt
@@ -5,9 +5,9 @@ import com.dobby.backend.domain.model.experiment.ApplyMethod
 import com.dobby.backend.domain.model.experiment.ExperimentPost
 import com.dobby.backend.domain.model.experiment.TargetGroup
 import com.dobby.backend.domain.model.member.Member
-import com.dobby.backend.infrastructure.database.entity.enums.GenderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.GenderType
 import com.dobby.backend.infrastructure.database.entity.enums.MatchType
-import com.dobby.backend.infrastructure.database.entity.enums.TimeSlot
+import com.dobby.backend.infrastructure.database.entity.enums.experiment.TimeSlot
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Area
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region
 import io.kotest.core.spec.style.BehaviorSpec

--- a/src/test/kotlin/com/dobby/backend/application/usecase/experiment/UpdateExperimentPostRecruitStatusUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/experiment/UpdateExperimentPostRecruitStatusUseCaseTest.kt
@@ -6,8 +6,8 @@ import com.dobby.backend.domain.gateway.experiment.ExperimentPostGateway
 import com.dobby.backend.domain.model.experiment.ApplyMethod
 import com.dobby.backend.domain.model.experiment.ExperimentPost
 import com.dobby.backend.domain.model.experiment.TargetGroup
-import com.dobby.backend.infrastructure.database.entity.enums.GenderType
-import com.dobby.backend.infrastructure.database.entity.enums.TimeSlot
+import com.dobby.backend.infrastructure.database.entity.enums.member.GenderType
+import com.dobby.backend.infrastructure.database.entity.enums.experiment.TimeSlot
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Area
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region
 import io.kotest.assertions.throwables.shouldThrow

--- a/src/test/kotlin/com/dobby/backend/application/usecase/member/CreateParticipantUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/member/CreateParticipantUseCaseTest.kt
@@ -5,9 +5,9 @@ import com.dobby.backend.domain.gateway.auth.TokenGateway
 import com.dobby.backend.domain.gateway.member.ParticipantGateway
 import com.dobby.backend.domain.model.member.Member
 import com.dobby.backend.domain.model.member.Participant
-import com.dobby.backend.infrastructure.database.entity.enums.GenderType
-import com.dobby.backend.infrastructure.database.entity.enums.ProviderType
-import com.dobby.backend.infrastructure.database.entity.enums.RoleType
+import com.dobby.backend.infrastructure.database.entity.enums.member.GenderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.ProviderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.RoleType
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Area
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region
 import io.kotest.core.spec.style.BehaviorSpec

--- a/src/test/kotlin/com/dobby/backend/application/usecase/member/CreateResearcherUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/member/CreateResearcherUseCaseTest.kt
@@ -6,9 +6,9 @@ import com.dobby.backend.domain.gateway.member.MemberGateway
 import com.dobby.backend.domain.gateway.member.ResearcherGateway
 import com.dobby.backend.domain.model.member.Member
 import com.dobby.backend.domain.model.member.Researcher
-import com.dobby.backend.infrastructure.database.entity.enums.MemberStatus
-import com.dobby.backend.infrastructure.database.entity.enums.ProviderType
-import com.dobby.backend.infrastructure.database.entity.enums.RoleType
+import com.dobby.backend.infrastructure.database.entity.enums.member.MemberStatus
+import com.dobby.backend.infrastructure.database.entity.enums.member.ProviderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.RoleType
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every

--- a/src/test/kotlin/com/dobby/backend/application/usecase/member/DeleteParticipantUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/member/DeleteParticipantUseCaseTest.kt
@@ -1,0 +1,75 @@
+package com.dobby.backend.application.usecase.member
+
+import com.dobby.backend.domain.exception.MemberNotFoundException
+import com.dobby.backend.domain.gateway.member.MemberGateway
+import com.dobby.backend.domain.gateway.member.MemberWithdrawalGateway
+import com.dobby.backend.domain.model.member.Member
+import com.dobby.backend.infrastructure.database.entity.enums.member.*
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.time.LocalDateTime
+
+class DeleteParticipantUseCaseTest : BehaviorSpec({
+    val memberGateway = mockk<MemberGateway>()
+    val memberWithdrawalGateway = mockk<MemberWithdrawalGateway>(relaxed = true)
+    val deleteParticipantUseCase = DeleteParticipantUseCase(memberGateway, memberWithdrawalGateway)
+
+    given("유효한 참여자(Participant)가 존재하는 경우") {
+        val memberId = "1"
+        val reasonType = WithdrawalReasonType.TOO_MANY_EMAILS
+        val reason = null
+        val member = Member(
+            id = memberId,
+            name = "지수",
+            oauthEmail = "participant@example.com",
+            contactEmail = "contact@example.com",
+            provider = ProviderType.GOOGLE,
+            status = MemberStatus.ACTIVE,
+            role = RoleType.PARTICIPANT,
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now(),
+            deletedAt = null
+        )
+
+        every { memberGateway.findByIdAndDeletedAtIsNull(memberId) } returns member
+        every { memberGateway.save(any()) } returns member.withdraw()
+
+        `when`("DeleteParticipantUseCase가 실행되면") {
+            val input = DeleteParticipantUseCase.Input(memberId, reasonType, reason)
+            val output = deleteParticipantUseCase.execute(input)
+
+            then("isSuccess가 true여야 한다") {
+                output.isSuccess shouldBe true
+            }
+
+            then("memberWithdrawalGateway.save가 올바른 탈퇴 기록으로 호출되어야 한다") {
+                verify {
+                    memberWithdrawalGateway.save(match {
+                        it.memberId == memberId &&
+                                it.reasonType == reasonType &&
+                                it.otherReason == reason
+                    })
+                }
+            }
+        }
+    }
+
+    given("참여자가 존재하지 않는 경우") {
+        val memberId = "non-existent"
+        every { memberGateway.findByIdAndDeletedAtIsNull(memberId) } returns null
+
+        `when`("DeleteParticipantUseCase가 실행되면") {
+            then("MemberNotFoundException 예외가 발생해야 한다") {
+                shouldThrow<MemberNotFoundException> {
+                    deleteParticipantUseCase.execute(
+                        DeleteParticipantUseCase.Input(memberId, WithdrawalReasonType.TOO_MANY_EMAILS, null)
+                    )
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/dobby/backend/application/usecase/member/DeleteResearcherUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/member/DeleteResearcherUseCaseTest.kt
@@ -1,0 +1,95 @@
+package com.dobby.backend.application.usecase.member
+
+import com.dobby.backend.domain.exception.MemberNotFoundException
+import com.dobby.backend.domain.gateway.email.VerificationGateway
+import com.dobby.backend.domain.gateway.member.MemberWithdrawalGateway
+import com.dobby.backend.domain.gateway.member.ResearcherGateway
+import com.dobby.backend.domain.model.member.Member
+import com.dobby.backend.domain.model.member.Researcher
+import com.dobby.backend.infrastructure.database.entity.enums.member.*
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.time.LocalDateTime
+
+class DeleteResearcherUseCaseTest : BehaviorSpec({
+    val researcherGateway = mockk<ResearcherGateway>()
+    val memberWithdrawalGateway = mockk<MemberWithdrawalGateway>(relaxed = true)
+    val verificationGateway = mockk<VerificationGateway>(relaxed = true)
+    val deleteResearcherUseCase = DeleteResearcherUseCase(
+        researcherGateway,
+        memberWithdrawalGateway,
+        verificationGateway
+    )
+
+    given("유효한 연구자가 존재하는 경우") {
+        val memberId = "1"
+        val reasonType = WithdrawalReasonType.SECURITY_CONCERN
+        val reason = null
+        val member = Member(
+            id = memberId,
+            name = "지수r",
+            oauthEmail = "researcher@example.com",
+            contactEmail = "contact@example.com",
+            provider = ProviderType.GOOGLE,
+            status = MemberStatus.ACTIVE,
+            role = RoleType.RESEARCHER,
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now(),
+            deletedAt = null
+        )
+        val researcher = Researcher(
+            id = "1",
+            member = member,
+            univEmail = "university@example.com",
+            emailVerified = true,
+            univName = "Some University",
+            major = "Computer Science",
+            labInfo = "Lab Info"
+        )
+
+        every { researcherGateway.findByMemberId(memberId) } returns researcher
+        every { researcherGateway.save(any()) } returns researcher.withdraw()
+
+        `when`("DeleteResearcherUseCase가 실행되면") {
+            val input = DeleteResearcherUseCase.Input(memberId, reasonType, reason)
+            val output = deleteResearcherUseCase.execute(input)
+
+            then("isSuccess가 true여야 한다") {
+                output.isSuccess shouldBe true
+            }
+
+            then("verificationGateway.deleteByUnivEmail이 연구자의 univEmail로 호출되어야 한다") {
+                verify { verificationGateway.deleteByUnivEmail("university@example.com") }
+            }
+
+            then("memberWithdrawalGateway.save가 올바른 탈퇴 기록으로 호출되어야 한다") {
+                verify {
+                    memberWithdrawalGateway.save(match {
+                        it.memberId == memberId &&
+                                it.reasonType == reasonType &&
+                                it.otherReason == reason
+                    })
+                }
+            }
+        }
+    }
+
+    given("연구자가 존재하지 않는 경우") {
+        val memberId = "non-existent"
+        every { researcherGateway.findByMemberId(memberId) } returns null
+
+        `when`("DeleteResearcherUseCase가 실행되면") {
+            then("MemberNotFoundException 예외가 발생해야 한다") {
+                shouldThrow<MemberNotFoundException> {
+                    deleteResearcherUseCase.execute(
+                        DeleteResearcherUseCase.Input(memberId, WithdrawalReasonType.RESEARCH_STOPPED, null)
+                    )
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/dobby/backend/application/usecase/member/GetParticipantInfoUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/member/GetParticipantInfoUseCaseTest.kt
@@ -5,7 +5,7 @@ import com.dobby.backend.domain.gateway.member.MemberGateway
 import com.dobby.backend.domain.gateway.member.ParticipantGateway
 import com.dobby.backend.domain.model.member.Member
 import com.dobby.backend.domain.model.member.Participant
-import com.dobby.backend.infrastructure.database.entity.enums.GenderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.GenderType
 import com.dobby.backend.infrastructure.database.entity.enums.MatchType
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Area
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region

--- a/src/test/kotlin/com/dobby/backend/application/usecase/member/GetResearcherInfoUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/member/GetResearcherInfoUseCaseTest.kt
@@ -29,7 +29,8 @@ class GetResearcherInfoUseCaseTest : BehaviorSpec({
             role = RoleType.RESEARCHER,
             status = MemberStatus.ACTIVE,
             createdAt = LocalDateTime.now(),
-            updatedAt = LocalDateTime.now()
+            updatedAt = LocalDateTime.now(),
+            deletedAt = null
         )
         val mockResearcher = Researcher(
             member = mockMember,

--- a/src/test/kotlin/com/dobby/backend/application/usecase/member/GetResearcherInfoUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/member/GetResearcherInfoUseCaseTest.kt
@@ -4,9 +4,9 @@ import com.dobby.backend.domain.exception.ResearcherNotFoundException
 import com.dobby.backend.domain.gateway.member.ResearcherGateway
 import com.dobby.backend.domain.model.member.Member
 import com.dobby.backend.domain.model.member.Researcher
-import com.dobby.backend.infrastructure.database.entity.enums.MemberStatus
-import com.dobby.backend.infrastructure.database.entity.enums.ProviderType
-import com.dobby.backend.infrastructure.database.entity.enums.RoleType
+import com.dobby.backend.infrastructure.database.entity.enums.member.MemberStatus
+import com.dobby.backend.infrastructure.database.entity.enums.member.ProviderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.RoleType
 import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.every
 import io.mockk.mockk

--- a/src/test/kotlin/com/dobby/backend/application/usecase/member/UpdateParticipantInfoUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/member/UpdateParticipantInfoUseCaseTest.kt
@@ -9,6 +9,10 @@ import com.dobby.backend.domain.model.member.Participant
 import com.dobby.backend.infrastructure.database.entity.enums.*
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Area
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region
+import com.dobby.backend.infrastructure.database.entity.enums.member.GenderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.MemberStatus
+import com.dobby.backend.infrastructure.database.entity.enums.member.ProviderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.RoleType
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.assertions.throwables.shouldThrow

--- a/src/test/kotlin/com/dobby/backend/application/usecase/member/UpdateParticipantInfoUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/member/UpdateParticipantInfoUseCaseTest.kt
@@ -34,7 +34,7 @@ class UpdateParticipantInfoUseCaseTest : BehaviorSpec({
             id = memberId,
             member = Member(id = memberId, name = "기존 이름", contactEmail = "old@example.com", oauthEmail = "oauth@example.com",
                 provider = ProviderType.NAVER, role = RoleType.PARTICIPANT, status = MemberStatus.ACTIVE,
-                createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now()),
+                createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now(), deletedAt = null),
             gender = GenderType.MALE,
             birthDate = LocalDate.of(1998, 5, 10),
             basicAddressInfo = Participant.AddressInfo(Region.SEOUL, Area.SEOUL_ALL),
@@ -105,7 +105,7 @@ class UpdateParticipantInfoUseCaseTest : BehaviorSpec({
             id = memberId,
             member = Member(id = memberId, name = "기존 이름", contactEmail = "old@example.com", oauthEmail = "oauth@example.com",
                 provider = ProviderType.NAVER, role = RoleType.PARTICIPANT, status = MemberStatus.ACTIVE,
-                createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now()),
+                createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now(), deletedAt = null),
             gender = GenderType.MALE,
             birthDate = LocalDate.of(1998, 5, 10),
             basicAddressInfo = Participant.AddressInfo(Region.SEOUL, Area.SEOUL_ALL),
@@ -149,7 +149,8 @@ class UpdateParticipantInfoUseCaseTest : BehaviorSpec({
                 role = RoleType.PARTICIPANT,
                 status = MemberStatus.ACTIVE,
                 createdAt = LocalDateTime.now(),
-                updatedAt = LocalDateTime.now()
+                updatedAt = LocalDateTime.now(),
+                deletedAt = null
             ),
             gender = GenderType.MALE,
             birthDate = LocalDate.of(1998, 5, 10),

--- a/src/test/kotlin/com/dobby/backend/application/usecase/member/UpdateResearcherInfoUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/member/UpdateResearcherInfoUseCaseTest.kt
@@ -6,9 +6,9 @@ import com.dobby.backend.domain.gateway.member.MemberGateway
 import com.dobby.backend.domain.gateway.member.ResearcherGateway
 import com.dobby.backend.domain.model.member.Member
 import com.dobby.backend.domain.model.member.Researcher
-import com.dobby.backend.infrastructure.database.entity.enums.MemberStatus
-import com.dobby.backend.infrastructure.database.entity.enums.ProviderType
-import com.dobby.backend.infrastructure.database.entity.enums.RoleType
+import com.dobby.backend.infrastructure.database.entity.enums.member.MemberStatus
+import com.dobby.backend.infrastructure.database.entity.enums.member.ProviderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.RoleType
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.assertions.throwables.shouldThrow

--- a/src/test/kotlin/com/dobby/backend/application/usecase/member/UpdateResearcherInfoUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/member/UpdateResearcherInfoUseCaseTest.kt
@@ -30,7 +30,7 @@ class UpdateResearcherInfoUseCaseTest : BehaviorSpec({
             member = Member(
                 id = memberId, name = "기존 연구자", contactEmail = "old@example.com",
                 oauthEmail = "oauth@example.com", provider = ProviderType.NAVER, role = RoleType.RESEARCHER,
-                status = MemberStatus.ACTIVE, createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now()
+                status = MemberStatus.ACTIVE, createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now(), deletedAt = null
             ),
             univEmail = "old@university.com",
             univName = "Old University",
@@ -101,7 +101,7 @@ class UpdateResearcherInfoUseCaseTest : BehaviorSpec({
             member = Member(
                 id = memberId, name = "기존 연구자", contactEmail = "old@example.com",
                 oauthEmail = "oauth@example.com", provider = ProviderType.NAVER, role = RoleType.RESEARCHER,
-                status = MemberStatus.ACTIVE, createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now()
+                status = MemberStatus.ACTIVE, createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now(), deletedAt = null
             ),
             univEmail = "old@university.com",
             univName = "Old University",
@@ -146,7 +146,8 @@ class UpdateResearcherInfoUseCaseTest : BehaviorSpec({
                 role = RoleType.RESEARCHER,
                 status = MemberStatus.ACTIVE,
                 createdAt = LocalDateTime.now(),
-                updatedAt = LocalDateTime.now()
+                updatedAt = LocalDateTime.now(),
+                deletedAt = null
             ),
             univEmail = "old@university.com",
             univName = "Old University",

--- a/src/test/kotlin/com/dobby/backend/application/usecase/member/email/GetMatchingExperimentPostsUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/member/email/GetMatchingExperimentPostsUseCaseTest.kt
@@ -6,6 +6,11 @@ import com.dobby.backend.domain.model.member.Member
 import com.dobby.backend.infrastructure.database.entity.enums.*
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Area
 import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region
+import com.dobby.backend.infrastructure.database.entity.enums.experiment.TimeSlot
+import com.dobby.backend.infrastructure.database.entity.enums.member.GenderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.MemberStatus
+import com.dobby.backend.infrastructure.database.entity.enums.member.ProviderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.RoleType
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every

--- a/src/test/kotlin/com/dobby/backend/application/usecase/member/email/GetMatchingExperimentPostsUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/member/email/GetMatchingExperimentPostsUseCaseTest.kt
@@ -39,7 +39,8 @@ class GetMatchingExperimentPostsUseCaseTest : BehaviorSpec({
                 provider = ProviderType.NAVER,
                 status = MemberStatus.ACTIVE,
                 createdAt = LocalDateTime.now(fixedClock),
-                updatedAt = LocalDateTime.now(fixedClock)
+                updatedAt = LocalDateTime.now(fixedClock),
+                deletedAt = null
             )
 
             val experimentPosts = listOf(

--- a/src/test/kotlin/com/dobby/backend/application/usecase/member/email/SendMatchingEmailUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/member/email/SendMatchingEmailUseCaseTest.kt
@@ -46,7 +46,8 @@ class SendMatchingEmailUseCaseTest : BehaviorSpec({
                 provider = ProviderType.NAVER,
                 status = MemberStatus.ACTIVE,
                 createdAt = LocalDateTime.now().minusDays(2),
-                updatedAt = LocalDateTime.now().minusDays(2)
+                updatedAt = LocalDateTime.now().minusDays(2),
+                deletedAt = null
             )
 
             val experimentPosts = listOf(
@@ -110,7 +111,8 @@ class SendMatchingEmailUseCaseTest : BehaviorSpec({
                 provider = ProviderType.NAVER,
                 status = MemberStatus.ACTIVE,
                 createdAt = LocalDateTime.now().minusDays(2),
-                updatedAt = LocalDateTime.now().minusDays(2)
+                updatedAt = LocalDateTime.now().minusDays(2),
+                deletedAt = null
             )
 
             val experimentPosts = listOf(

--- a/src/test/kotlin/com/dobby/backend/application/usecase/member/email/SendMatchingEmailUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/member/email/SendMatchingEmailUseCaseTest.kt
@@ -12,6 +12,11 @@ import com.dobby.backend.domain.gateway.UrlGeneratorGateway
 import com.dobby.backend.domain.gateway.email.EmailGateway
 import com.dobby.backend.domain.gateway.member.MemberGateway
 import com.dobby.backend.domain.model.experiment.ExperimentPost
+import com.dobby.backend.infrastructure.database.entity.enums.experiment.TimeSlot
+import com.dobby.backend.infrastructure.database.entity.enums.member.GenderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.MemberStatus
+import com.dobby.backend.infrastructure.database.entity.enums.member.ProviderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.RoleType
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.assertions.throwables.shouldThrow

--- a/src/test/kotlin/com/dobby/backend/infrastructure/token/JwtTokenProviderTest.kt
+++ b/src/test/kotlin/com/dobby/backend/infrastructure/token/JwtTokenProviderTest.kt
@@ -27,7 +27,7 @@ class JwtTokenProviderTest : BehaviorSpec() {
         given("회원 정보가 주어지고") {
             val member = Member(id = "1", oauthEmail = "dlawotn3@naver.com", contactEmail = "dlawotn3@naver.com",
                 provider = ProviderType.NAVER, role = RoleType.PARTICIPANT, name = "dobby",
-                status = MemberStatus.ACTIVE, createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now())
+                status = MemberStatus.ACTIVE, createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now(), deletedAt = null)
             val authorities = listOf(SimpleGrantedAuthority(member.role?.name ?: "PARTICIPANT"))
             val authentication = UsernamePasswordAuthenticationToken(member.id, null, authorities)
 
@@ -43,7 +43,7 @@ class JwtTokenProviderTest : BehaviorSpec() {
         given("유효한 JWT 토큰이 주어지고") {
             val member = Member(id = "1", oauthEmail = "dlawotn3@naver.com", contactEmail = "dlawotn3@naver.com",
                 provider = ProviderType.NAVER, role = RoleType.PARTICIPANT, name = "dobby",
-                status = MemberStatus.ACTIVE, createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now())
+                status = MemberStatus.ACTIVE, createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now(), deletedAt = null)
             val authorities = listOf(SimpleGrantedAuthority(member.role?.name ?: "PARTICIPANT"))
             val authentication = UsernamePasswordAuthenticationToken(member.id, null, authorities)
             val validToken = jwtTokenProvider.generateAccessToken(authentication)

--- a/src/test/kotlin/com/dobby/backend/infrastructure/token/JwtTokenProviderTest.kt
+++ b/src/test/kotlin/com/dobby/backend/infrastructure/token/JwtTokenProviderTest.kt
@@ -2,9 +2,9 @@ package com.dobby.backend.infrastructure.token
 
 import com.dobby.backend.domain.exception.AuthenticationTokenNotValidException
 import com.dobby.backend.domain.model.member.Member
-import com.dobby.backend.infrastructure.database.entity.enums.MemberStatus
-import com.dobby.backend.infrastructure.database.entity.enums.ProviderType
-import com.dobby.backend.infrastructure.database.entity.enums.RoleType
+import com.dobby.backend.infrastructure.database.entity.enums.member.MemberStatus
+import com.dobby.backend.infrastructure.database.entity.enums.member.ProviderType
+import com.dobby.backend.infrastructure.database.entity.enums.member.RoleType
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe


### PR DESCRIPTION
## 💡 작업 내용
- 회원 탈퇴 API 구현 (무결성을 위해 제약 조건을 그대로 유지하면서 마스킹 진행)
  - Member -> `HOLD` 전환, `deletedAt` 할당, `oauthEmail` 마스킹, `contactEmail` null 할당
  - Researcher ->  `lab_info` null 할당, `major`, `univEmail`, `univName` 마스킹
    - 재가입이 가능하도록 Verification 테이블에서 해당 회원의 row를 제거
  - Participant -> 민감 정보가 없으므로 그대로 둠
- 탈퇴 사유를 저장하기 위한 `member_withdrawal` 테이블 추가
- `findById` -> `findByIdAndDeletedAtIsNull`
  - 이후에 신고 기능이 추가될 수 있으므로 `HOLD`는 제외하고 필터링 
- 탈퇴한 회원에게는 추천 공고 이메일이 가지 않도록 `DeletedAtIsNull` 조건 추가
- 추가된 탈퇴 유즈케이스에 대한 테스트 코드 추가

**탈퇴한 경우, 테이블 상태**
- `member`
  <img width="500" alt="스크린샷 2025-02-08 오후 11 39 23" src="https://github.com/user-attachments/assets/83522e28-3936-45fe-bb31-067869624693" />
- `researcher`
  <img width="500" alt="스크린샷 2025-02-08 오후 11 39 33" src="https://github.com/user-attachments/assets/ac809ecc-419a-4e99-bb75-5e3da6a0252b" />
- `member_withdrawal`
  <img width="500" alt="스크린샷 2025-02-08 오후 11 39 50" src="https://github.com/user-attachments/assets/8e823bda-d116-483f-8a78-f47831018949" />

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- 참여자/연구자 모두 탈퇴 후, 재가입이 되는지 API 호출을 통해 확인했습니다


## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-233

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 새롭게 추가된 멤버 삭제 API를 통해 회원 탈퇴 요청 시 지정한 사유를 반영하여 탈퇴 처리가 이루어집니다.
  - 실험 게시글 상세 정보에 업로더의 활성 상태가 표시되어, 게시글 작성자의 현재 상태를 확인할 수 있습니다.
  - 회원 역할 조회 기능이 추가되어, 회원 ID에 따른 역할 정보를 쉽게 확인할 수 있습니다.

- **Bug Fixes**
  - 삭제된 회원을 고려하여 회원 조회 로직이 개선되었습니다.

- **Refactor / Chores**
  - 회원 및 실험 관련 데이터의 분류와 관리가 개선되어, 내부 데이터 구조가 보다 명확해졌습니다.
  - 여러 테스트 및 유틸리티 코드가 업데이트되어, 전반적인 시스템 안정성과 관리성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
