### PR TITLE
[YS-285] refactor: 실험 공고 상세 조회 UseCase가 프레젠테이션 계층을 참조하지 않도록 리팩토링

### DIFF
--- a/src/main/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostDetailUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostDetailUseCase.kt
@@ -5,7 +5,12 @@ import com.dobby.backend.domain.exception.ExperimentPostNotFoundException
 import com.dobby.backend.domain.gateway.experiment.ExperimentPostGateway
 import com.dobby.backend.domain.model.experiment.ExperimentPost
 import com.dobby.backend.domain.model.experiment.TargetGroup
-import com.dobby.backend.presentation.api.dto.response.experiment.ExperimentPostDetailResponse
+import com.dobby.backend.infrastructure.database.entity.enums.GenderType
+import com.dobby.backend.infrastructure.database.entity.enums.MatchType
+import com.dobby.backend.infrastructure.database.entity.enums.TimeSlot
+import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Area
+import com.dobby.backend.infrastructure.database.entity.enums.areaInfo.Region
+import java.time.LocalDate
 
 class GetExperimentPostDetailUseCase(
     private val experimentPostGateway: ExperimentPostGateway
@@ -17,8 +22,47 @@ class GetExperimentPostDetailUseCase(
     )
 
     data class Output(
-        val experimentPostDetailResponse: ExperimentPostDetailResponse
+        val experimentPostDetail: ExperimentPostDetail
     )
+
+    data class ExperimentPostDetail(
+        val experimentPostId: String,
+        val title: String,
+        val uploadDate: LocalDate,
+        val uploaderName: String,
+        val views: Int,
+        val recruitStatus: Boolean,
+        val summary: Summary,
+        val targetGroup: TargetGroup,
+        val address: Address,
+        val content: String,
+        val imageList: List<String>,
+        val isAuthor: Boolean
+    ) {
+        data class Summary(
+            val startDate: LocalDate?,
+            val endDate: LocalDate?,
+            val leadResearcher: String,
+            val matchType: MatchType,
+            val reward: String,
+            val count: Int?,
+            val timeRequired: TimeSlot?
+        )
+
+        data class TargetGroup(
+            val startAge: Int?,
+            val endAge: Int?,
+            val genderType: GenderType,
+            val otherCondition: String?
+        )
+
+        data class Address(
+            val univName: String?,
+            val region: Region?,
+            val area: Area?,
+            val detailedAddress: String?
+        )
+    }
 
     override fun execute(input: Input): Output {
         val experimentPost = experimentPostGateway.findById(input.experimentPostId)
@@ -27,30 +71,30 @@ class GetExperimentPostDetailUseCase(
         experimentPostGateway.save(experimentPost)
 
         return Output(
-            experimentPostDetailResponse = experimentPost.toDetailResponse(input.memberId)
+            experimentPostDetail = experimentPost.toExperimentPostDetail(input.memberId)
         )
     }
 }
 
-fun ExperimentPost.toDetailResponse(memberId: String?): ExperimentPostDetailResponse {
-    return ExperimentPostDetailResponse(
+fun ExperimentPost.toExperimentPostDetail(memberId: String?): GetExperimentPostDetailUseCase.ExperimentPostDetail {
+    return GetExperimentPostDetailUseCase.ExperimentPostDetail(
         experimentPostId = this.id,
         title = this.title,
         uploadDate = this.createdAt.toLocalDate(),
         uploaderName = this.member.name,
         views = this.views,
         recruitStatus = this.recruitStatus,
-        summary = this.toSummaryResponse(),
-        targetGroup = this.targetGroup.toResponse(),
-        address = this.toAddressResponse(),
+        summary = this.toSummary(),
+        targetGroup = this.targetGroup.toTargetGroup(),
+        address = this.toAddress(),
         content = this.content,
         imageList = this.images.map { it.imageUrl },
         isAuthor = this.member.id == memberId
     )
 }
 
-fun ExperimentPost.toSummaryResponse(): ExperimentPostDetailResponse.SummaryResponse {
-    return ExperimentPostDetailResponse.SummaryResponse(
+fun ExperimentPost.toSummary(): GetExperimentPostDetailUseCase.ExperimentPostDetail.Summary {
+    return GetExperimentPostDetailUseCase.ExperimentPostDetail.Summary(
         startDate = this.startDate,
         endDate = this.endDate,
         leadResearcher = this.leadResearcher,
@@ -61,8 +105,8 @@ fun ExperimentPost.toSummaryResponse(): ExperimentPostDetailResponse.SummaryResp
     )
 }
 
-fun TargetGroup.toResponse(): ExperimentPostDetailResponse.TargetGroupResponse {
-    return ExperimentPostDetailResponse.TargetGroupResponse(
+fun TargetGroup.toTargetGroup(): GetExperimentPostDetailUseCase.ExperimentPostDetail.TargetGroup {
+    return GetExperimentPostDetailUseCase.ExperimentPostDetail.TargetGroup(
         startAge = this.startAge,
         endAge = this.endAge,
         genderType = this.genderType,
@@ -70,8 +114,8 @@ fun TargetGroup.toResponse(): ExperimentPostDetailResponse.TargetGroupResponse {
     )
 }
 
-fun ExperimentPost.toAddressResponse(): ExperimentPostDetailResponse.AddressResponse {
-    return ExperimentPostDetailResponse.AddressResponse(
+fun ExperimentPost.toAddress(): GetExperimentPostDetailUseCase.ExperimentPostDetail.Address {
+    return GetExperimentPostDetailUseCase.ExperimentPostDetail.Address(
         univName = this.univName,
         region = this.region,
         area = this.area,

--- a/src/main/kotlin/com/dobby/backend/presentation/api/mapper/ExperimentPostMapper.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/mapper/ExperimentPostMapper.kt
@@ -148,11 +148,10 @@ object ExperimentPostMapper {
             )
     }
 
-    fun toUpdateExperimentPostResponse(response: UpdateExperimentPostUseCase.Output): UpdateExperimentPostResponse{
-        val responseDto= UpdateExperimentPostResponse(
+    fun toUpdateExperimentPostResponse(response: UpdateExperimentPostUseCase.Output): UpdateExperimentPostResponse {
+        return UpdateExperimentPostResponse(
             postInfo = toUpdatePostInfo(response.postInfo)
         )
-        return responseDto
     }
 
 
@@ -165,18 +164,48 @@ object ExperimentPostMapper {
 
     fun toGetExperimentPostDetailResponse(response: GetExperimentPostDetailUseCase.Output): ExperimentPostDetailResponse {
         return ExperimentPostDetailResponse(
-            experimentPostId = response.experimentPostDetailResponse.experimentPostId,
-            title = response.experimentPostDetailResponse.title,
-            uploadDate = response.experimentPostDetailResponse.uploadDate,
-            uploaderName = response.experimentPostDetailResponse.uploaderName,
-            views = response.experimentPostDetailResponse.views,
-            recruitStatus = response.experimentPostDetailResponse.recruitStatus,
-            summary = response.experimentPostDetailResponse.summary,
-            targetGroup = response.experimentPostDetailResponse.targetGroup,
-            address = response.experimentPostDetailResponse.address,
-            content = response.experimentPostDetailResponse.content,
-            imageList = response.experimentPostDetailResponse.imageList,
-            isAuthor = response.experimentPostDetailResponse.isAuthor
+            experimentPostId = response.experimentPostDetail.experimentPostId,
+            title = response.experimentPostDetail.title,
+            uploadDate = response.experimentPostDetail.uploadDate,
+            uploaderName = response.experimentPostDetail.uploaderName,
+            views = response.experimentPostDetail.views,
+            recruitStatus = response.experimentPostDetail.recruitStatus,
+            summary = response.experimentPostDetail.summary.toResponse(),
+            targetGroup = response.experimentPostDetail.targetGroup.toResponse(),
+            address = response.experimentPostDetail.address.toResponse(),
+            content = response.experimentPostDetail.content,
+            imageList = response.experimentPostDetail.imageList,
+            isAuthor = response.experimentPostDetail.isAuthor
+        )
+    }
+
+    private fun GetExperimentPostDetailUseCase.ExperimentPostDetail.Summary.toResponse(): ExperimentPostDetailResponse.SummaryResponse {
+        return ExperimentPostDetailResponse.SummaryResponse(
+            startDate = this.startDate,
+            endDate = this.endDate,
+            leadResearcher = this.leadResearcher,
+            matchType = this.matchType,
+            reward = this.reward,
+            count = this.count,
+            timeRequired = this.timeRequired
+        )
+    }
+
+    private fun GetExperimentPostDetailUseCase.ExperimentPostDetail.TargetGroup.toResponse(): ExperimentPostDetailResponse.TargetGroupResponse {
+        return ExperimentPostDetailResponse.TargetGroupResponse(
+            startAge = this.startAge,
+            endAge = this.endAge,
+            genderType = this.genderType,
+            otherCondition = this.otherCondition
+        )
+    }
+
+    private fun GetExperimentPostDetailUseCase.ExperimentPostDetail.Address.toResponse(): ExperimentPostDetailResponse.AddressResponse {
+        return ExperimentPostDetailResponse.AddressResponse(
+            univName = this.univName,
+            region = this.region,
+            area = this.area,
+            detailedAddress = this.detailedAddress
         )
     }
 

--- a/src/test/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostDetailUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostDetailUseCaseTest.kt
@@ -76,9 +76,9 @@ class GetExperimentPostDetailUseCaseTest : BehaviorSpec({
             val initialViews = experimentPost.views
             val result = getExperimentPostDetailUseCase.execute(input)
 
-            then("isAuthor가 true인 experimentPostDetailResponse가 반환된다") {
-                result.experimentPostDetailResponse.title shouldBe experimentPost.title
-                result.experimentPostDetailResponse.isAuthor shouldBe true
+            then("isAuthor가 true인 experimentPostDetail이 반환된다") {
+                result.experimentPostDetail.title shouldBe experimentPost.title
+                result.experimentPostDetail.isAuthor shouldBe true
             }
 
             then("views가 증가했는지 확인한다") {
@@ -90,9 +90,9 @@ class GetExperimentPostDetailUseCaseTest : BehaviorSpec({
             val input = GetExperimentPostDetailUseCase.Input(experimentPostId = experimentPostId, memberId = "2")
             val result = getExperimentPostDetailUseCase.execute(input)
 
-            then("isAuthor가 false인 experimentPostDetailResponse가 반환된다") {
-                result.experimentPostDetailResponse.title shouldBe experimentPost.title
-                result.experimentPostDetailResponse.isAuthor shouldBe false
+            then("isAuthor가 false인 experimentPostDetail이 반환된다") {
+                result.experimentPostDetail.title shouldBe experimentPost.title
+                result.experimentPostDetail.isAuthor shouldBe false
             }
         }
 
@@ -100,9 +100,9 @@ class GetExperimentPostDetailUseCaseTest : BehaviorSpec({
             val input = GetExperimentPostDetailUseCase.Input(experimentPostId = experimentPostId, memberId = null)
             val result = getExperimentPostDetailUseCase.execute(input)
 
-            then("isAuthor가 false인 experimentPostDetailResponse가 반환된다") {
-                result.experimentPostDetailResponse.title shouldBe experimentPost.title
-                result.experimentPostDetailResponse.isAuthor shouldBe false
+            then("isAuthor가 false인 experimentPostDetail이 반환된다") {
+                result.experimentPostDetail.title shouldBe experimentPost.title
+                result.experimentPostDetail.isAuthor shouldBe false
             }
         }
     }
@@ -122,3 +122,4 @@ class GetExperimentPostDetailUseCaseTest : BehaviorSpec({
         }
     }
 })
+


### PR DESCRIPTION
## 💡 작업 내용
- 실험 공고 상세 조회 UseCase가 프레젠테이션 계층을 참조하지 않도록 리팩토링
- 관련 테스트 코드 수정

## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- #89 를 작업하다가 클린아키텍처 원칙에 위배된 사항을 인지해 해당 PR을 올렸습니다. 😨


## 🔗 Jira 티켓

---
https://yappsocks.atlassian.net/browse/YS-285

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
	- 실험 포스트 상세 정보가 개편되어 제목, 업로드 날짜, 작성자, 조회수, 모집 상태 등 다양한 핵심 정보와 함께 연구 기간, 연구자, 보상, 참여 대상, 주소 등의 세부 항목이 제공됩니다.
- 리팩토링
	- 응답 데이터 구조 및 변환 로직을 개선하여 정보 표시에 일관성을 높이고 유지 보수성을 강화하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->