### PR TITLE
[YS-284] feat: 실험 공고 전체 조회 최신순/오래된순 옵션 추가

### DIFF
--- a/src/main/kotlin/com/dobby/backend/application/service/ExperimentPostService.kt
+++ b/src/main/kotlin/com/dobby/backend/application/service/ExperimentPostService.kt
@@ -44,6 +44,7 @@ class ExperimentPostService(
     @Transactional
     fun getExperimentPosts(input: GetExperimentPostsUseCase.Input): List<GetExperimentPostsUseCase.Output> {
         validateFilter(input)
+        validateSortOrder(input.pagination.order)
         return getExperimentPostsUseCase.execute(input)
     }
 

--- a/src/main/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostsUseCase.kt
+++ b/src/main/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostsUseCase.kt
@@ -41,6 +41,7 @@ class GetExperimentPostsUseCase (
     data class PaginationInput(
         val page: Int = 1,
         val count: Int = 6,
+        val order : String = "DESC"
     )
 
     data class Output(
@@ -72,7 +73,8 @@ class GetExperimentPostsUseCase (
         val pagination = Pagination(input.pagination.page, input.pagination.count)
         val posts = experimentPostGateway.findExperimentPostsByCustomFilter(
             domainFilter,
-            pagination
+            pagination,
+            input.pagination.order
         )
 
         return posts?.map { post ->

--- a/src/main/kotlin/com/dobby/backend/domain/gateway/experiment/ExperimentPostGateway.kt
+++ b/src/main/kotlin/com/dobby/backend/domain/gateway/experiment/ExperimentPostGateway.kt
@@ -11,7 +11,7 @@ import java.time.LocalDateTime
 interface ExperimentPostGateway {
     fun save(experimentPost: ExperimentPost): ExperimentPost
     fun updateExperimentPost(experimentPost: ExperimentPost): ExperimentPost
-    fun findExperimentPostsByCustomFilter(customFilter: CustomFilter, pagination: Pagination): List<ExperimentPost>?
+    fun findExperimentPostsByCustomFilter(customFilter: CustomFilter, pagination: Pagination, order: String): List<ExperimentPost>?
     fun findById(experimentPostId: String): ExperimentPost?
     fun countExperimentPostsByRegion(region: Region): Int
     fun countExperimentPostsByRegionAndRecruitStatus(region: Region, recruitStatus: Boolean): Int

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/repository/ExperimentPostCustomRepository.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/repository/ExperimentPostCustomRepository.kt
@@ -11,7 +11,8 @@ import java.time.LocalDate
 interface ExperimentPostCustomRepository {
     fun findExperimentPostsByCustomFilter(
         customFilter: CustomFilter,
-        pagination: Pagination
+        pagination: Pagination,
+        order: String
     ): List<ExperimentPostEntity>?
 
     fun updateExperimentPostStatus(currentDate : LocalDate): Long

--- a/src/main/kotlin/com/dobby/backend/infrastructure/database/repository/ExperimentPostCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/database/repository/ExperimentPostCustomRepositoryImpl.kt
@@ -35,7 +35,8 @@ class ExperimentPostCustomRepositoryImpl (
 
     override fun findExperimentPostsByCustomFilter(
         customFilter: CustomFilter,
-        pagination: Pagination
+        pagination: Pagination,
+        order: String
     ): List<ExperimentPostEntity>? {
         val post = QExperimentPostEntity.experimentPostEntity
         val recruitStatusCondition = when (customFilter.recruitStatus) {
@@ -56,7 +57,7 @@ class ExperimentPostCustomRepositoryImpl (
             )
             .offset((pagination.page - 1L) * pagination.count)
             .limit(pagination.count.toLong())
-            .orderBy(post.createdAt.desc())
+            .orderBy(getOrderClause(order))
             .fetch()
     }
 

--- a/src/main/kotlin/com/dobby/backend/infrastructure/gateway/experiment/ExperimentPostGatewayImpl.kt
+++ b/src/main/kotlin/com/dobby/backend/infrastructure/gateway/experiment/ExperimentPostGatewayImpl.kt
@@ -26,11 +26,13 @@ class ExperimentPostGatewayImpl(
 
     override fun findExperimentPostsByCustomFilter(
         customFilter: CustomFilter,
-        pagination: Pagination
+        pagination: Pagination,
+        order: String
     ): List<ExperimentPost>? {
         return experimentPostCustomRepository.findExperimentPostsByCustomFilter(
             customFilter,
-            pagination
+            pagination,
+            order
         )?.map{ it.toDomain()}
     }
 

--- a/src/main/kotlin/com/dobby/backend/presentation/api/controller/ExperimentPostController.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/controller/ExperimentPostController.kt
@@ -155,10 +155,11 @@ class ExperimentPostController (
         @RequestParam(required = false) areas: List<Area>?,
         @RequestParam(required = false, defaultValue = "ALL") recruitStatus: RecruitStatus,
         @RequestParam(defaultValue = "1") page: Int,
-        @RequestParam(defaultValue = "6") count: Int
+        @RequestParam(defaultValue = "6") count: Int,
+        @RequestParam(defaultValue = "DESC") order: String
     ): PaginatedResponse<ExperimentPostResponse> {
         val customFilter = ExperimentPostMapper.toUseCaseCustomFilter(matchType, gender, age, region, areas, recruitStatus)
-        val pagination = ExperimentPostMapper.toGetExperimentPostsUseCasePagination(page, count)
+        val pagination = ExperimentPostMapper.toGetExperimentPostsUseCasePagination(page, count, order)
         val input = ExperimentPostMapper.toGetExperimentPostsUseCaseInput(customFilter, pagination)
         val posts = experimentPostService.getExperimentPosts(input)
 

--- a/src/main/kotlin/com/dobby/backend/presentation/api/mapper/ExperimentPostMapper.kt
+++ b/src/main/kotlin/com/dobby/backend/presentation/api/mapper/ExperimentPostMapper.kt
@@ -284,11 +284,14 @@ object ExperimentPostMapper {
     }
 
     fun toGetExperimentPostsUseCasePagination(
-        page: Int, count: Int
+        page: Int,
+        count: Int,
+        order: String
     ) : GetExperimentPostsUseCase.PaginationInput {
         return GetExperimentPostsUseCase.PaginationInput(
             page = page,
             count = count,
+            order = order
         )
     }
 

--- a/src/test/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostsUseCaseTest.kt
+++ b/src/test/kotlin/com/dobby/backend/application/usecase/experiment/GetExperimentPostsUseCaseTest.kt
@@ -36,7 +36,7 @@ class GetExperimentPostsUseCaseTest : BehaviorSpec({
             locationTarget = LocationTargetInput(region = Region.SEOUL, areas = listOf(Area.SEODAEMUNGU, Area.MAPOGU)),
             recruitStatus = RecruitStatus.ALL
         )
-        val pagination = PaginationInput(page = 1, count = 6)
+        val pagination = PaginationInput(page = 1, count = 6, order = "DESC")
         val input = Input(customFilter, pagination)
 
         val mockPost = ExperimentPost(
@@ -95,7 +95,8 @@ class GetExperimentPostsUseCaseTest : BehaviorSpec({
                     customFilter.locationTarget?.let { LocationTarget(it.region, it.areas) },
                     customFilter.recruitStatus
                 ),
-                Pagination(pagination.page, pagination.count)
+                Pagination(pagination.page, pagination.count),
+                pagination.order
             )
         } returns listOf(mockPost)
 
@@ -178,7 +179,8 @@ class GetExperimentPostsUseCaseTest : BehaviorSpec({
                     customFilter.locationTarget?.let { LocationTarget(it.region, it.areas) },
                     customFilter.recruitStatus
                 ),
-                Pagination(pagination.page, pagination.count)
+                Pagination(pagination.page, pagination.count),
+                pagination.order
             )
         } returns listOf(mockPost)
 
@@ -258,7 +260,8 @@ class GetExperimentPostsUseCaseTest : BehaviorSpec({
                     customFilter.locationTarget?.let { LocationTarget(it.region, it.areas) },
                     customFilter.recruitStatus
                 ),
-                Pagination(pagination.page, pagination.count)
+                Pagination(pagination.page, pagination.count),
+                pagination.order
             )
         } returns listOf(mockPost)
 
@@ -337,7 +340,8 @@ class GetExperimentPostsUseCaseTest : BehaviorSpec({
                     customFilter.locationTarget?.let { LocationTarget(it.region, it.areas) },
                     customFilter.recruitStatus
                 ),
-                Pagination(pagination.page, pagination.count)
+                Pagination(pagination.page, pagination.count),
+                pagination.order
             )
         } returns mutableListOf()
 
@@ -416,7 +420,8 @@ class GetExperimentPostsUseCaseTest : BehaviorSpec({
                     customFilter.locationTarget?.let { LocationTarget(it.region, it.areas) },
                     customFilter.recruitStatus
                 ),
-                Pagination(pagination.page, pagination.count)
+                Pagination(pagination.page, pagination.count),
+                pagination.order
             )
         } returns listOf(mockPost)
 


### PR DESCRIPTION
## 💡 작업 내용
- 기존의 공고 전체조회 로직인 `GetExperimentPostsUseCase` 에 정렬값(최신순, 오래된순)을 조회하는 기능을 추가하였습니다.

### 최신순 정렬 - order = `DESC`
![공고 전체조회(DESC)](https://github.com/user-attachments/assets/e2441f65-ba76-4ae9-a59e-27c4fa527d1b)

### 오래된순 정렬 - order = `ASC`
![공고 전체조회(ASC)](https://github.com/user-attachments/assets/f4b7d211-c5c1-445e-b7c3-484764171117)


## ✅ 셀프 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
- [x] 본인을 assign 해주세요.
- [x] 해당 PR에 맞는 label을 붙여주세요.

## 🙋🏻‍ 확인해주세요
- 관련된 Discussion 등이 있다면 첨부해주세요
